### PR TITLE
implement orgvyper cell magic

### DIFF
--- a/boa/ipython.py
+++ b/boa/ipython.py
@@ -13,6 +13,15 @@ class TitanoboaMagic(ipython.Magics):
         c = boa.loads_partial(cell)
         return c
 
+    @ipython.cell_magic
+    def orgvyper(self, line, cell):
+        # note use of eval here is ok since everything is being
+        # eval'ed anyway.
+        c = boa.loads_partial(cell)
+        if line:
+            boa.env.contracts[line] = c
+        boa.env._ = c
+        return line
 
 def load_ipython_extension(ipy_module):
     ipy_module.register_magics(TitanoboaMagic())


### PR DESCRIPTION
Uses the `boa.env.contracts` object to store references to deployed contracts in between org-mode code blocks

this is needed because org-mode code blocks pass each other their results as strings instead of object references. however, the environment for a session persists across code blocks which is what enables this workaround

as implemented, we use the `line` argument to the cell magic function to store a contract with a given name under `boa.env.contracts`.

The only other cases where we store contracts in this object, addresses are used as the key, so there is no risk of conflict between these two use-cases using the same contracts object. 

Example usage:

```
Load the extension and import boa
#+BEGIN_SRC jupyter-python :session py
import boa
%load_ext boa.ipython
#+END_SRC

#+RESULTS:

#+BEGIN_SRC jupyter-python :session py :cache no :type boa.contract.VyperDeployer
%%orgvyper deployer
MY_IMMUTABLE: immutable(uint256)

@external
def __init__(some_number: uint256):
    MY_IMMUTABLE = some_number
@external
def foo() -> uint256:
    return MY_IMMUTABLE
#+END_SRC

#+RESULTS:
: <boa.contract.VyperDeployer at 0x11a3d79a0>

#+BEGIN_SRC jupyter-python :session py
deployer = boa.env.contracts['deployer']
deployer.deploy(3).foo()
#+END_SRC

#+RESULTS:
: 3
```