### PR TITLE
fix: replace `eth_abi` with `eth_stdlib`

### DIFF
--- a/boa/contract.py
+++ b/boa/contract.py
@@ -41,7 +41,7 @@ from boa.vyper.decoder_utils import ByteAddressableStorage, decode_vyper_object
 
 try:
     # `eth-stdlib` requires python 3.10 and above
-    from eth.codecs.abi import abi_decode, abi_encode
+    from eth.codecs.abi import decode as abi_decode, encode as abi_encode
 
 except ImportError:
     from eth_abi import decode_single as abi_decode, encode_single as abi_encode

--- a/boa/contract.py
+++ b/boa/contract.py
@@ -46,6 +46,7 @@ try:
 except ImportError:
     from eth_abi import decode_single as decode, encode_single as encode
 
+
 # build a reverse map from the format we have in pc_pos_map to AST nodes
 # TODO move to ast_utils
 def ast_map_of(ast_node):

--- a/boa/contract.py
+++ b/boa/contract.py
@@ -41,10 +41,10 @@ from boa.vyper.decoder_utils import ByteAddressableStorage, decode_vyper_object
 
 try:
     # `eth-stdlib` requires python 3.10 and above
-    from eth.codecs.abi import decode, encode
+    from eth.codecs.abi import abi_decode, abi_encode
 
 except ImportError:
-    from eth_abi import decode_single as decode, encode_single as encode
+    from eth_abi import decode_single as abi_decode, encode_single as abi_encode
 
 
 # build a reverse map from the format we have in pc_pos_map to AST nodes
@@ -201,7 +201,7 @@ class ErrorDetail:
         # decode error msg if it's "Error(string)"
         # b"\x08\xc3y\xa0" == method_id("Error(string)")
         if isinstance(err.args[0], bytes) and err.args[0][:4] == b"\x08\xc3y\xa0":
-            return decode("(string)", err.args[0][4:])[0]
+            return ("(string)", err.args[0][4:])[0]
 
         return repr(err)
 
@@ -499,7 +499,7 @@ class VyperContract(_BaseContract):
             return None
 
         return_typ = calculate_type_for_external_return(vyper_typ)
-        ret = decode(return_typ.abi_type.selector_name(), computation.output)
+        ret = abi_decode(return_typ.abi_type.selector_name(), computation.output)
 
         # unwrap the tuple if needed
         if not isinstance(vyper_typ, TupleType):
@@ -815,7 +815,7 @@ class VyperFunction:
 
         # allow things with `.address` to be encode-able
         args = [getattr(arg, "address", arg) for arg in args]
-        encoded_args = encode(args_abi_type, tuple(args))
+        encoded_args = abi_encode(args_abi_type, tuple(args))
 
         return method_id + encoded_args
 

--- a/boa/contract.py
+++ b/boa/contract.py
@@ -201,7 +201,7 @@ class ErrorDetail:
         # decode error msg if it's "Error(string)"
         # b"\x08\xc3y\xa0" == method_id("Error(string)")
         if isinstance(err.args[0], bytes) and err.args[0][:4] == b"\x08\xc3y\xa0":
-            return ("(string)", err.args[0][4:])[0]
+            return abi_decode("(string)", err.args[0][4:])[0]
 
         return repr(err)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "eth-abi",
     "py-evm",
     "eth-typing",
+    "eth-stdlib",
 
 # required for forking:
     "requests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "eth-abi",
     "py-evm",
     "eth-typing",
-    "eth-stdlib",
+    'eth-stdlib; python_version >= "3.10"',
 
 # required for forking:
     "requests",

--- a/tests/sim_veYFI.py
+++ b/tests/sim_veYFI.py
@@ -1,4 +1,5 @@
 import boa
+from eth_utils import to_checksum_address
 from vyper.utils import checksum_encode
 
 import time
@@ -18,7 +19,7 @@ def timeit(msg):
 def format_addr(t):
     if isinstance(t, str):
         t = t.encode("utf-8")
-    return t.rjust(20, b"\x00")
+    return to_checksum_address(t.rjust(20, b"\x00"))
 
 BUNNY = boa.env.generate_address("bunny")
 MILKY = boa.env.generate_address("milky")


### PR DESCRIPTION
Partial solution for #21 by replacing `eth_abi` with `eth_stdlib` for encoding and decoding.

One issue is that `eth_stdlib` requires python 3.10, but Vyper targets python 3.8 and above.