### PR TITLE
add `boa.env.time_travel()`

### DIFF
--- a/boa/environment.py
+++ b/boa/environment.py
@@ -478,15 +478,9 @@ class Env:
         return self.vm.state.computation_class.apply_message(self.vm.state, msg, tx_ctx)
 
     # function to time travel
-    def time_travel(self, sleep_time, block_steps: int = None):
-        self.vm.patch.timestamp += sleep_time
-        if not block_steps:
-            self.vm.patch.block_number += sleep_time // 12
-        else:
-            self.vm.patch.block_number += block_steps
-
-    def mine(self, block_time: int = 12):
-        self.time_travel(block_time, 1)
+    def time_travel(self, time_delta: int, block_delta: int = 12):
+        self.vm.patch.timestamp += time_delta
+        self.vm.patch.block_number += time_delta // block_delta
 
 
 GENESIS_PARAMS = {"difficulty": constants.GENESIS_DIFFICULTY, "gas_limit": int(1e8)}

--- a/boa/environment.py
+++ b/boa/environment.py
@@ -477,11 +477,11 @@ class Env:
         block_delta: int = 12,
     ):
 
-        if not (seconds or blocks):
+        if seconds is None == blocks is None:
             raise ValueError("One of seconds or blocks should be set")
-        if seconds and not blocks:
+        if seconds is not None:
             blocks = seconds // block_delta
-        elif not seconds and blocks:
+        else:
             seconds = blocks * block_delta
 
         self.vm.patch.timestamp += seconds

--- a/boa/environment.py
+++ b/boa/environment.py
@@ -478,9 +478,20 @@ class Env:
         return self.vm.state.computation_class.apply_message(self.vm.state, msg, tx_ctx)
 
     # function to time travel
-    def time_travel(self, time_delta: int, block_delta: int = 12):
-        self.vm.patch.timestamp += time_delta
-        self.vm.patch.block_number += time_delta // block_delta
+    def time_travel(self, seconds=None, blocks=None, block_delta=12):
+
+        if seconds is None and blocks is None:
+            raise ValueError("One of seconds or blocks should be set")
+        if seconds is not None:
+            if seconds <= 0:
+                raise ValueError("seconds must be greater than 0")
+            blocks = seconds // block_delta
+        else:
+            if blocks <= 0:
+                raise ValueError("blocks must be greater than 0")
+            seconds = blocks * block_delta
+        self.vm.patch.timestamp += seconds
+        self.vm.patch.block_number += blocks
 
 
 GENESIS_PARAMS = {"difficulty": constants.GENESIS_DIFFICULTY, "gas_limit": int(1e8)}

--- a/boa/environment.py
+++ b/boa/environment.py
@@ -485,8 +485,8 @@ class Env:
         else:
             self.vm.patch.block_number += block_steps
 
-    def mine(self, block_timestamp: int = 12):
-        self.time_travel(block_timestamp, 1)
+    def mine(self, block_time: int = 12):
+        self.time_travel(block_time, 1)
 
 
 GENESIS_PARAMS = {"difficulty": constants.GENESIS_DIFFICULTY, "gas_limit": int(1e8)}

--- a/boa/environment.py
+++ b/boa/environment.py
@@ -266,14 +266,6 @@ class Env:
 
         self._contracts = {}
 
-    @property
-    def timestamp(self):
-        return self.vm.state.timestamp
-
-    @property
-    def block_number(self):
-        return self.vm.state.block_number
-
     def _init_vm(self):
         self.vm = self.chain.get_vm()
 

--- a/boa/environment.py
+++ b/boa/environment.py
@@ -266,6 +266,14 @@ class Env:
 
         self._contracts = {}
 
+    @property
+    def timestamp(self):
+        return self.vm.state.timestamp
+
+    @property
+    def block_number(self):
+        return self.vm.state.block_number
+
     def _init_vm(self):
         self.vm = self.chain.get_vm()
 
@@ -470,9 +478,15 @@ class Env:
         return self.vm.state.computation_class.apply_message(self.vm.state, msg, tx_ctx)
 
     # function to time travel
-    def time_travel(self, sleep_time):
+    def time_travel(self, sleep_time, block_steps: int = None):
         self.vm.patch.timestamp += sleep_time
-        self.vm.patch.block_number += sleep_time // 12
+        if not block_steps:
+            self.vm.patch.block_number += sleep_time // 12
+        else:
+            self.vm.patch.block_number += block_steps
+
+    def mine(self, block_timestamp: int = 12):
+        self.time_travel(block_timestamp, 1)
 
 
 GENESIS_PARAMS = {"difficulty": constants.GENESIS_DIFFICULTY, "gas_limit": int(1e8)}

--- a/boa/environment.py
+++ b/boa/environment.py
@@ -470,18 +470,20 @@ class Env:
         return self.vm.state.computation_class.apply_message(self.vm.state, msg, tx_ctx)
 
     # function to time travel
-    def time_travel(self, seconds=None, blocks=None, block_delta=12):
+    def time_travel(
+        self,
+        seconds: Optional[int] = None,
+        blocks: Optional[int] = None,
+        block_delta: int = 12,
+    ):
 
-        if seconds is None and blocks is None:
+        if not (seconds or blocks):
             raise ValueError("One of seconds or blocks should be set")
-        if seconds is not None:
-            if seconds <= 0:
-                raise ValueError("seconds must be greater than 0")
+        if seconds and not blocks:
             blocks = seconds // block_delta
-        else:
-            if blocks <= 0:
-                raise ValueError("blocks must be greater than 0")
+        elif not seconds and blocks:
             seconds = blocks * block_delta
+
         self.vm.patch.timestamp += seconds
         self.vm.patch.block_number += blocks
 

--- a/boa/environment.py
+++ b/boa/environment.py
@@ -477,7 +477,7 @@ class Env:
         block_delta: int = 12,
     ):
 
-        if seconds is None == blocks is None:
+        if (seconds is None) == (blocks is None):
             raise ValueError("One of seconds or blocks should be set")
         if seconds is not None:
             blocks = seconds // block_delta

--- a/boa/vyper/contract.py
+++ b/boa/vyper/contract.py
@@ -10,13 +10,13 @@ from typing import Any, Optional
 
 import vyper
 import vyper.ast as vy_ast
-from vyper.ast.utils import parse_to_ast
 import vyper.ir.compile_ir as compile_ir
 import vyper.semantics.namespace as vy_ns
 import vyper.semantics.validation as validation
 from eth.exceptions import VMError
 from eth_typing import Address
 from eth_utils import to_canonical_address, to_checksum_address
+from vyper.ast.utils import parse_to_ast
 from vyper.codegen.core import calculate_type_for_external_return
 from vyper.codegen.function_definitions import generate_ir_for_function
 from vyper.codegen.ir_node import IRnode

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -455,8 +455,8 @@ Low-Level Functionality
 
         Fast forward, increase the chain timestamp and block number.
 
-        :param seconds: Change timestamp by a certain positive amount.
-        :param blocks: Change block number by a certain positive amount.
+        :param seconds: Change current timestamp by `seconds` seconds.
+        :param blocks: Change block number by `blocks` blocks.
         :param block_delta: The time between two blocks. Set to 12 as default.
 
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -451,18 +451,12 @@ Low-Level Functionality
         :param pc: The program counter to start the execution at.
         :returns: The return value from the top-level call.
 
-    .. method:: time_travel(sleep_time: int, block_steps: int = None)
+    .. method:: time_travel(time_delta: int, block_delta: int = 12)
 
-        Fast forward, increase the chain timestamp and block number. If ``block_steps`` is None, it assumes a 12 second block time. Else, it fast-forwards by ``block_steps``.
+        Fast forwards, increase the chain timestamp and block number.
 
-        :param sleep_time: The time delta to increase by.
-        :param block_steps: Number of blocks to travel.
-
-    .. method:: mine(block_time: int = 12)
-
-        Pushes block timestamp and block number by a single block. ``block_timestamp`` is set at a default value of 12 sec.
-
-        :param block_time: Time between subsequent blocks.
+        :param time_delta: The time delta to increase by.
+        :param block_delta: The time between two blocks. Set to 12 as default.
 
 
 .. module:: boa.vyper.contract

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -451,11 +451,18 @@ Low-Level Functionality
         :param pc: The program counter to start the execution at.
         :returns: The return value from the top-level call.
 
-    .. method:: time_travel(delta: int)
+    .. method:: time_travel(sleep_time: int, block_steps: int = None)
 
-        Fast forward, increase the chain timestamp and block number.
+        Fast forward, increase the chain timestamp and block number. If ``block_steps`` is None, it assumes a 12 second block time. Else, it fast-forwards by ``block_steps``.
 
-        :param delta: The time delta to increase by.
+        :param sleep_time: The time delta to increase by.
+        :param block_steps: Number of blocks to travel.
+
+    .. method:: mine(block_time: int = 12)
+
+        Pushes block timestamp and block number by a single block. ``block_timestamp`` is set at a default value of 12 sec.
+
+        :param block_time: Time between subsequent blocks.
 
 
 .. module:: boa.vyper.contract

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -451,11 +451,12 @@ Low-Level Functionality
         :param pc: The program counter to start the execution at.
         :returns: The return value from the top-level call.
 
-    .. method:: time_travel(time_delta: int, block_delta: int = 12)
+    .. method:: time_travel(seconds = None, blocks = None, block_delta=12)
 
-        Fast forwards, increase the chain timestamp and block number.
+        Fast forward, increase the chain timestamp and block number.
 
-        :param time_delta: The time delta to increase by.
+        :param seconds: Change timestamp by a certain positive amount.
+        :param blocks: Change block number by a certain positive amount.
         :param block_delta: The time between two blocks. Set to 12 as default.
 
 

--- a/tests/unitary/test_injects.py
+++ b/tests/unitary/test_injects.py
@@ -1,7 +1,8 @@
 import pytest
 from hypothesis import given
-from boa.test.strategies import strategy
+
 import boa
+from boa.test.strategies import strategy
 
 contract_code = """
 totalSupply: public(uint256)
@@ -13,11 +14,13 @@ def test_mint(amt: uint256):
     self.totalSupply += amt
 """
 
+
 @pytest.fixture(scope="module")
 def contract():
     s = boa.loads(contract_code)
     s.inject_function(inject_code)
     return s
+
 
 def test_inject_force(contract):
     with pytest.raises(ValueError):
@@ -25,8 +28,8 @@ def test_inject_force(contract):
         contract.inject_function(inject_code)
 
     contract.inject_function(inject_code, force=True)
- 
- 
+
+
 @given(x=strategy("uint256"))
 def test_inject(contract, x):
     contract.inject.test_mint(x)

--- a/tests/unitary/test_time_travel.py
+++ b/tests/unitary/test_time_travel.py
@@ -1,0 +1,31 @@
+import pytest
+
+import boa
+
+
+def test_revert_negative_inputs():
+    with pytest.raises(ValueError):
+        boa.env.time_travel(seconds=-1)
+    with pytest.raises(ValueError):
+        boa.env.time_travel(blocks=-1)
+
+
+def test_no_inputs():
+    with pytest.raises(ValueError):
+        boa.env.time_travel()
+
+
+def test_block_travel():
+    old_block = boa.env.block_number
+    old_timestamp = boa.env.timestamp
+    boa.env.time_travel(blocks=42069, block_delta=12)
+    assert boa.env.block_number == old_block + 42069
+    assert boa.env.timestamp == old_timestamp + 42069 * 12
+
+
+def test_seconds_travel():
+    old_timestamp = boa.env.timestamp
+    old_block = boa.env.block_number
+    boa.env.time_travel(seconds=42069, block_delta=12)
+    assert boa.env.timestamp == old_timestamp + 42069
+    assert boa.env.block_number == old_block + 42069 // 12

--- a/tests/unitary/test_time_travel.py
+++ b/tests/unitary/test_time_travel.py
@@ -3,13 +3,6 @@ import pytest
 import boa
 
 
-def test_revert_negative_inputs():
-    with pytest.raises(ValueError):
-        boa.env.time_travel(seconds=-1)
-    with pytest.raises(ValueError):
-        boa.env.time_travel(blocks=-1)
-
-
 def test_no_inputs():
     with pytest.raises(ValueError):
         boa.env.time_travel()
@@ -19,15 +12,15 @@ def test_block_travel():
     state = boa.env.vm.state
     old_block = state.block_number
     old_timestamp = state.timestamp
-    boa.env.time_travel(blocks=42069, block_delta=12)
-    assert state.block_number == old_block + 42069
-    assert state.timestamp == old_timestamp + 42069 * 12
+    boa.env.time_travel(blocks=420)
+    assert state.block_number == old_block + 420
+    assert state.timestamp == old_timestamp + 420 * 12
 
 
 def test_seconds_travel():
     state = boa.env.vm.state
     old_timestamp = state.timestamp
     old_block = state.block_number
-    boa.env.time_travel(seconds=42069, block_delta=12)
-    assert state.timestamp == old_timestamp + 42069
-    assert state.block_number == old_block + 42069 // 12
+    boa.env.time_travel(seconds=69)
+    assert state.timestamp == old_timestamp + 69
+    assert state.block_number == old_block + 69 // 12

--- a/tests/unitary/test_time_travel.py
+++ b/tests/unitary/test_time_travel.py
@@ -16,16 +16,18 @@ def test_no_inputs():
 
 
 def test_block_travel():
-    old_block = boa.env.block_number
-    old_timestamp = boa.env.timestamp
+    state = boa.env.vm.state
+    old_block = state.block_number
+    old_timestamp = state.timestamp
     boa.env.time_travel(blocks=42069, block_delta=12)
-    assert boa.env.block_number == old_block + 42069
-    assert boa.env.timestamp == old_timestamp + 42069 * 12
+    assert state.block_number == old_block + 42069
+    assert state.timestamp == old_timestamp + 42069 * 12
 
 
 def test_seconds_travel():
-    old_timestamp = boa.env.timestamp
-    old_block = boa.env.block_number
+    state = boa.env.vm.state
+    old_timestamp = state.timestamp
+    old_block = state.block_number
     boa.env.time_travel(seconds=42069, block_delta=12)
-    assert boa.env.timestamp == old_timestamp + 42069
-    assert boa.env.block_number == old_block + 42069 // 12
+    assert state.timestamp == old_timestamp + 42069
+    assert state.block_number == old_block + 42069 // 12


### PR DESCRIPTION
easy option to mine a single block (with a user specified block timestamp, set to default at 12 sec: or 11?)

also added block_timestamp and block_number properties.