### PR TITLE
Feat: profile calls

### DIFF
--- a/boa/test/plugin.py
+++ b/boa/test/plugin.py
@@ -27,13 +27,74 @@ hypothesis.core.HypothesisHandle.__init__ = _HypothesisHandle__init__  # type: i
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "ignore_isolation")
+    config.addinivalue_line("markers", "profile_calls")
+
+    pytest.call_profile = {}
 
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_call(item: pytest.Item) -> Generator:
 
-    if not item.get_closest_marker("ignore_isolation"):
+    ignore_isolation = item.get_closest_marker("ignore_isolation")
+    profile_calls = item.get_closest_marker("profile_calls")
+    isolate = not (ignore_isolation and profile_calls)
+
+    if isolate:
+
         with boa.env.anchor():
             yield
+
     else:
+
         yield
+
+
+def pytest_sessionfinish(session, exitstatus):
+
+    if not pytest.call_profile:
+        pass
+
+    import statistics
+    import sys
+
+    from rich.console import Console
+    from rich.table import Table
+
+    # generate means, stds for each
+    call_profiles = {}
+    for key, gas_used in pytest.call_profile.items():
+        call_profile = {}
+
+        call_profile["mean"] = statistics.mean(gas_used)
+        call_profile["median"] = statistics.median(gas_used)
+        call_profile["min"] = min(gas_used)
+        call_profile["max"] = max(gas_used)
+        if len(gas_used) == 1:
+            call_profile["stdev"] = 0
+        else:
+            call_profile["stdev"] = int(round(statistics.stdev(gas_used), 2))
+
+        call_profiles[key] = call_profile
+
+    # print rich table
+    table = Table(title="\nCall Profile")
+    table.add_column("Method", justify="right", style="cyan", no_wrap=True)
+    table.add_column("Mean", style="magenta")
+    table.add_column("Median", style="magenta")
+    table.add_column("Stdev", style="magenta")
+    table.add_column("Min", style="magenta")
+    table.add_column("Max", style="magenta")
+
+    for key in call_profiles.keys():
+        profile = call_profiles[key]
+        table.add_row(
+            key,
+            str(profile["mean"]),
+            str(profile["median"]),
+            str(profile["stdev"]),
+            str(profile["min"]),
+            str(profile["max"]),
+        )
+
+    console = Console(file=sys.stdout)
+    console.print(table)

--- a/boa/test/plugin.py
+++ b/boa/test/plugin.py
@@ -32,6 +32,23 @@ def pytest_configure(config):
     pytest.call_profile = {}
 
 
+def _enable_call_profiling(item):
+    profile_test = item.get_closest_marker("profile_calls") is not None
+    if not profile_test:
+        return
+
+    profile_calls = item.get_closest_marker("profile_calls").args
+    if len(profile_calls) > 0:
+
+        for call in profile_calls:
+            fixture_name = call.split(".")[0]
+            for name, fixture in item.funcargs.items():
+
+                if name == fixture_name:
+
+                    fixture.profile_calls = True
+
+
 def _profile_calls(item):
 
     profile_calls = item.get_closest_marker("profile_calls").args
@@ -63,6 +80,7 @@ def _profile_calls(item):
 def pytest_runtest_call(item: pytest.Item) -> Generator:
 
     ignore_isolation = item.get_closest_marker("ignore_isolation") is not None
+    _enable_call_profiling(item)
 
     if not ignore_isolation:
         with boa.env.anchor():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,17 +21,15 @@ dependencies = [
     "eth-typing",
     "hypothesis",
     "pytest",
-#'eth-stdlib; python_version >= "3.10"',
+    "rich",
+    #'eth-stdlib; python_version >= "3.10"',
 
-# required for forking:
+    # required for forking:
     "requests",
 ]
 
 [project.optional-dependencies]
-forking-recommended = [
-    "plyvel",
-    "ujson",
-]
+forking-recommended = ["plyvel", "ujson"]
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/tests/unitary/test_call_profiling/test_call_profile.py
+++ b/tests/unitary/test_call_profiling/test_call_profile.py
@@ -19,7 +19,7 @@ SETTINGS = {"max_examples": 20, "deadline": None}
 
 @pytest.fixture(scope="module")
 def boa_contract():
-    return boa.loads(source_code)
+    return boa.loads(source_code, name="TestContract")
 
 
 def test_call_profiling_disabled_by_default(boa_contract):
@@ -29,7 +29,7 @@ def test_call_profiling_disabled_by_default(boa_contract):
 
 
 @pytest.mark.parametrize("a,b", [(42, 69), (420, 690), (42, 690), (420, 69)])
-@pytest.mark.ignore_isolation
+@pytest.mark.profile_calls("boa_contract.foo", "boa_contract.bar")
 def test_populate_call_profile_property(boa_contract, a, b):
 
     boa_contract.profile_calls = True
@@ -37,12 +37,3 @@ def test_populate_call_profile_property(boa_contract, a, b):
     boa_contract.bar(a, b)
 
     assert boa_contract.call_profile
-    combined_calls = {}
-    for d in (pytest.call_profile, boa_contract.call_profile):
-        for key, value in d.items():
-            if key not in combined_calls.keys():
-                combined_calls[key] = value
-            else:
-                combined_calls[key].extend(value)
-
-    pytest.call_profile = combined_calls

--- a/tests/unitary/test_call_profiling/test_call_profile.py
+++ b/tests/unitary/test_call_profiling/test_call_profile.py
@@ -1,0 +1,48 @@
+import pytest
+
+import boa
+
+source_code = """
+@external
+@view
+def foo(a: uint256, b: uint256) -> uint256:
+    return unsafe_mul(a, b) + unsafe_div(a, b)
+
+@external
+@view
+def bar(a: uint256, b: uint256) -> uint256:
+    return isqrt(unsafe_div(a, b) + unsafe_mul(a, b))
+"""
+
+SETTINGS = {"max_examples": 20, "deadline": None}
+
+
+@pytest.fixture(scope="module")
+def boa_contract():
+    return boa.loads(source_code)
+
+
+def test_call_profiling_disabled_by_default(boa_contract):
+
+    assert not boa_contract.profile_calls
+    assert not boa_contract.call_profile
+
+
+@pytest.mark.parametrize("a,b", [(42, 69), (420, 690), (42, 690), (420, 69)])
+@pytest.mark.ignore_isolation
+def test_populate_call_profile_property(boa_contract, a, b):
+
+    boa_contract.profile_calls = True
+    boa_contract.foo(a, b)
+    boa_contract.bar(a, b)
+
+    assert boa_contract.call_profile
+    combined_calls = {}
+    for d in (pytest.call_profile, boa_contract.call_profile):
+        for key, value in d.items():
+            if key not in combined_calls.keys():
+                combined_calls[key] = value
+            else:
+                combined_calls[key].extend(value)
+
+    pytest.call_profile = combined_calls

--- a/tests/unitary/test_call_profiling/test_call_profile.py
+++ b/tests/unitary/test_call_profiling/test_call_profile.py
@@ -39,7 +39,6 @@ def test_call_profiling_disabled_by_default(boa_contract):
 @pytest.mark.profile_calls("boa_contract.foo", "boa_contract.bar")
 def test_populate_call_profile_property(boa_contract, a, b, c):
 
-    boa_contract.profile_calls = True
     boa_contract.foo(a, b)
     boa_contract.bar(a, b)
 


### PR DESCRIPTION
Enables call profiling. User needs to set up their profiling tests similar to the following example:

```
@pytest.mark.parametrize(
    "a,b,c", [(42, 69, 1), (420, 690, 2), (42, 690, 3), (420, 69, 4)]
)
@pytest.mark.profile_calls("boa_contract.foo", "boa_contract.bar")
def test_populate_call_profile_property(boa_contract, a, b, c):

    boa_contract.foo(a, b)
    boa_contract.bar(a, b)

    assert boa_contract.call_profile
```

which generates:
```
tests/unitary/test_call_profiling/test_call_profile.py .....                                                                                     [100%] 
                                               
                  Call Profile                  
┏━━━━━━━━┳━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━┳━━━━━━┓
┃ Method ┃ Mean ┃ Median ┃ Stdev ┃ Min  ┃ Max  ┃
┡━━━━━━━━╇━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━╇━━━━━━┩
│    foo │ 188  │ 188.0  │ 0     │ 188  │ 188  │
│    bar │ 5275 │ 5275.0 │ 0     │ 5275 │ 5275 │
└────────┴──────┴────────┴───────┴──────┴──────┘
```