### PR TITLE
Handle empty hex strings ('0x') returned by latest ganache versions

### DIFF
--- a/boa/vm/fork.py
+++ b/boa/vm/fork.py
@@ -33,6 +33,8 @@ def _to_hex(s: int) -> str:
 
 
 def _to_int(hex_str: str) -> int:
+    if hex_str == '0x':
+        return 0
     return int(hex_str, 16)
 
 

--- a/boa/vm/fork.py
+++ b/boa/vm/fork.py
@@ -33,7 +33,7 @@ def _to_hex(s: int) -> str:
 
 
 def _to_int(hex_str: str) -> int:
-    if hex_str == '0x':
+    if hex_str == "0x":
         return 0
     return int(hex_str, 16)
 


### PR DESCRIPTION
When using boa with a ganache (v7.7.2) local fork, I ran into the following error when trying to retrieve a value:

![image](https://user-images.githubusercontent.com/25791237/209757715-18f23462-dfbf-401e-b91a-c199cfab840f.png)

This happens because recent version of ganache return "0x" for empty values instead of "0x0" or "0x0000000000000000000000000000000000000000000000000000000000000000". 

This fix handles this edge case
