### PR TITLE
Fix parsing of reason comments on multiline statements & stack trace error on forked contracts

### DIFF
--- a/boa/vyper/ast_utils.py
+++ b/boa/vyper/ast_utils.py
@@ -29,9 +29,8 @@ def _extract_reason(comment: str) -> Any:
 
 # extract the dev revert reason at a given line.
 # somewhat heuristic.
-def reason_at(source_code: str, lineno: int) -> Optional[Tuple[str, str]]:
-    line = get_line(source_code, lineno)
-    c = _get_comment(line)
+def extract_reason(source_code) -> Optional[Tuple[str, str]]:
+    c = _get_comment(source_code)
     if c is not None:
         return _extract_reason(c)
     return None


### PR DESCRIPTION
Fixes #52 
I've modified `DevReason` to remove `line_no` in the `at` method and simply pass the multiline source code to extract comments from. If better to keep ability to localize error with line numbers, could add an `end_line` instead and extract the relevant lines accordingly.

Fixes #53 
Just handled the case where `child_obj` is None because the contract for which the external call failed is not part of the environment's contracts