### PR TITLE
Handle edge-case where contract lookup in environment fails

### DIFF
--- a/boa/vyper/contract.py
+++ b/boa/vyper/contract.py
@@ -623,6 +623,8 @@ class VyperContract(_BaseContract):
 
         child = computation.children[-1]
         child_obj = self.env.lookup_contract(child.msg.code_address)
+        if not child_obj:
+            return StackTrace(ret)
         child_trace = child_obj.vyper_stack_trace(child)
         return StackTrace(child_trace + ret)
 

--- a/boa/vyper/contract.py
+++ b/boa/vyper/contract.py
@@ -623,7 +623,7 @@ class VyperContract(_BaseContract):
 
         child = computation.children[-1]
         child_obj = self.env.lookup_contract(child.msg.code_address)
-        if not child_obj:
+        if child_obj is None:
             return StackTrace(ret)
         child_trace = child_obj.vyper_stack_trace(child)
         return StackTrace(child_trace + ret)


### PR DESCRIPTION
Fixes #53
Just handled the case where child_obj is None because the contract for which the external call failed is not part of the environment's contracts