### PR TITLE
Handle stack traces with unknown contracts

### DIFF
--- a/boa/vyper/contract.py
+++ b/boa/vyper/contract.py
@@ -628,18 +628,11 @@ class VyperContract(_BaseContract):
             # inspired by answers in https://stackoverflow.com/q/1603940/
             raise strip_internal_frames(b) from None
 
-    def vyper_stack_trace(self, computation, unknown=False):
-        if unknown:
-            ret = StackTrace(
-                [
-                    f"<Unknown location in unknown contract {computation.msg.code_address.hex()}>"
-                ]
-            )
-        else:
-            ret = StackTrace([ErrorDetail.from_computation(self, computation)])
-            error_detail = self.find_error_meta(computation.code)
-            if error_detail not in EXTERNAL_CALL_ERRORS:
-                return ret
+    def vyper_stack_trace(self, computation):
+        ret = StackTrace([ErrorDetail.from_computation(self, computation)])
+        error_detail = self.find_error_meta(computation.code)
+        if error_detail not in EXTERNAL_CALL_ERRORS:
+            return ret
 
         if len(computation.children) == 0:
             return ret

--- a/boa/vyper/contract.py
+++ b/boa/vyper/contract.py
@@ -231,17 +231,21 @@ def trace_for_unknown_contract(computation, env):
     ret = StackTrace(
         [f"<Unknown location in unknown contract {computation.msg.code_address.hex()}>"]
     )
+    return _handle_child_trace(computation, env, ret)
+
+
+def _handle_child_trace(computation, env, return_trace):
     if len(computation.children) == 0:
-        return ret
+        return return_trace
     if not computation.children[-1].is_error:
-        return ret
+        return return_trace
     child = computation.children[-1]
     child_obj = env.lookup_contract(child.msg.code_address)
     if child_obj is None:
         child_trace = trace_for_unknown_contract(child, env)
     else:
         child_trace = child_obj.vyper_stack_trace(child)
-    return StackTrace(child_trace + ret)
+    return StackTrace(child_trace + return_trace)
 
 
 # "pattern match" a BoaError. tries to match fields of the error
@@ -633,19 +637,7 @@ class VyperContract(_BaseContract):
         error_detail = self.find_error_meta(computation.code)
         if error_detail not in EXTERNAL_CALL_ERRORS:
             return ret
-
-        if len(computation.children) == 0:
-            return ret
-        if not computation.children[-1].is_error:
-            return ret
-
-        child = computation.children[-1]
-        child_obj = self.env.lookup_contract(child.msg.code_address)
-        if child_obj is None:
-            child_trace = trace_for_unknown_contract(child, self.env)
-        else:
-            child_trace = child_obj.vyper_stack_trace(child)
-        return StackTrace(child_trace + ret)
+        return _handle_child_trace(computation, self.env, ret)
 
     def line_profile(self, computation=None):
         computation = computation or self._computation


### PR DESCRIPTION
#57

Recurse when the contract is unknown and fill in the missing stack frames with the unknown contract's address.