### PR TITLE
chore: pin `eth_abi` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = ["Topic :: Software Development"]
 # Requirements
 dependencies = [
     "vyper @ git+https://github.com/vyperlang/vyper.git@a5995a91b769544b43819ef68ab6be5b6c6e1274",
-    "eth-abi",
+    "eth-abi == 3.0.1",
     "py-evm",
     "eth-typing",
     "hypothesis",


### PR DESCRIPTION
There is a breaking change in `eth_abi` where `decode_single` / `encode_single` has been deprecated after `3.0.1`, and the types and values for decode/encode need to be provided as a list - e.g. `encode(["uint256"], [1])` instead of `encode("uint256", 1)` previously.

This PR pins `eth_abi` to `3.0.1` to resolve this issue. In the long term, `eth_abi` can be dropped once support for python 3.9 and 3.9 is dropped and we can switch to `eth-stdlib` entirely.