### PR TITLE
Implement precompile decorator

### DIFF
--- a/boa/__init__.py
+++ b/boa/__init__.py
@@ -6,8 +6,8 @@ from boa.environment import (
     deregister_precompile,
     enable_pyevm_verbose_logging,
     patch_opcode,
+    precompile,
     register_precompile,
-    precompile
 )
 from boa.interpret import BoaError, load, load_partial, loads, loads_partial
 from boa.vyper.contract import check_boa_error_matches

--- a/boa/__init__.py
+++ b/boa/__init__.py
@@ -2,13 +2,7 @@ import contextlib
 import sys
 
 from boa.debugger import BoaDebug
-from boa.environment import (
-    Env,
-    deregister_precompile,
-    enable_pyevm_verbose_logging,
-    patch_opcode,
-    register_precompile,
-)
+from boa.environment import Env, enable_pyevm_verbose_logging, patch_opcode
 from boa.interpret import BoaError, load, load_partial, loads, loads_partial
 from boa.precompile import precompile
 from boa.vyper.contract import check_boa_error_matches

--- a/boa/__init__.py
+++ b/boa/__init__.py
@@ -6,10 +6,10 @@ from boa.environment import (
     deregister_precompile,
     enable_pyevm_verbose_logging,
     patch_opcode,
-    precompile,
     register_precompile,
 )
 from boa.interpret import BoaError, load, load_partial, loads, loads_partial
+from boa.precompile import precompile
 from boa.vyper.contract import check_boa_error_matches
 
 # turn off tracebacks if we are in repl

--- a/boa/__init__.py
+++ b/boa/__init__.py
@@ -7,6 +7,7 @@ from boa.environment import (
     enable_pyevm_verbose_logging,
     patch_opcode,
     register_precompile,
+    precompile
 )
 from boa.interpret import BoaError, load, load_partial, loads, loads_partial
 from boa.vyper.contract import check_boa_error_matches

--- a/boa/environment.py
+++ b/boa/environment.py
@@ -472,7 +472,7 @@ class Env:
         )
         msg._fake_codesize = fake_codesize  # type: ignore
         msg._start_pc = start_pc  # type: ignore
-        msg._contract = contract
+        msg._contract = contract  # type: ignore
         tx_ctx = BaseTransactionContext(origin=_addr(sender), gas_price=self._gas_price)
         return self.vm.state.computation_class.apply_message(self.vm.state, msg, tx_ctx)
 

--- a/boa/environment.py
+++ b/boa/environment.py
@@ -109,40 +109,6 @@ def patch_opcode(opcode_value, fn):
 _precompiles = {}
 
 
-def extract_arg_types(signature: str) -> str:
-    # Extract argument types and their names using regex
-
-    args = signature.split("(")[1].split(")")[0].split(",")
-    cleaned_args = [x.split(":")[1].strip().split("[")[0].lower() for x in args]
-
-    # Combine the cleaned argument types and return them in parentheses
-    return f"({', '.join(cleaned_args)})"
-
-
-def precompile(signature: str):
-    def decorator(func):
-        def wrapper(computation):
-            # Decode input arguments from message data
-            message_data = computation.msg.data_as_bytes
-            input_args = abi.decode(extract_arg_types(signature), message_data[4:])
-
-            # Call the original function with decoded input arguments
-            result = func(*input_args)
-
-            # Encode the result to be ABI-compatible
-            output_signature = signature.split("->")[1].strip()
-            # wrap output_signature in parentheses to make it a tuple if it's not already
-            if not output_signature.startswith("("):
-                output_signature = f"({output_signature})"
-            computation.output = abi.encode(output_signature, [result])
-
-            return computation
-
-        return wrapper
-
-    return decorator
-
-
 def register_precompile(address, fn, force=False):
     global _precompiles
     address = _addr(address)

--- a/boa/environment.py
+++ b/boa/environment.py
@@ -108,14 +108,16 @@ def patch_opcode(opcode_value, fn):
 # on all envs.
 _precompiles = {}
 
+
 def extract_arg_types(signature: str) -> str:
     # Extract argument types and their names using regex
 
     args = signature.split("(")[1].split(")")[0].split(",")
-    cleaned_args = [x.split(":")[1].strip().split('[')[0].lower() for x in args]
+    cleaned_args = [x.split(":")[1].strip().split("[")[0].lower() for x in args]
 
     # Combine the cleaned argument types and return them in parentheses
     return f"({', '.join(cleaned_args)})"
+
 
 def precompile(signature: str):
     def decorator(func):

--- a/boa/environment.py
+++ b/boa/environment.py
@@ -108,6 +108,38 @@ def patch_opcode(opcode_value, fn):
 # on all envs.
 _precompiles = {}
 
+def extract_arg_types(signature: str) -> str:
+    # Extract argument types and their names using regex
+
+    args = signature.split("(")[1].split(")")[0].split(",")
+    cleaned_args = [x.split(":")[1].strip().split('[')[0].lower() for x in args]
+
+    # Combine the cleaned argument types and return them in parentheses
+    return f"({', '.join(cleaned_args)})"
+
+def precompile(signature: str):
+    def decorator(func):
+        def wrapper(computation):
+            # Decode input arguments from message data
+            message_data = computation.msg.data_as_bytes
+            input_args = abi.decode(extract_arg_types(signature), message_data[4:])
+
+            # Call the original function with decoded input arguments
+            result = func(*input_args)
+
+            # Encode the result to be ABI-compatible
+            output_signature = signature.split("->")[1].strip()
+            # wrap output_signature in parentheses to make it a tuple if it's not already
+            if not output_signature.startswith("("):
+                output_signature = f"({output_signature})"
+            computation.output = abi.encode(output_signature, [result])
+
+            return computation
+
+        return wrapper
+
+    return decorator
+
 
 def register_precompile(address, fn, force=False):
     global _precompiles

--- a/boa/environment.py
+++ b/boa/environment.py
@@ -4,6 +4,7 @@
 import contextlib
 import logging
 import sys
+import warnings
 from typing import Any, Iterator, Optional, Union
 
 import eth.constants as constants
@@ -109,7 +110,11 @@ def patch_opcode(opcode_value, fn):
 _precompiles = {}
 
 
-def register_precompile(address, fn, force=False):
+def register_precompile(*args, **kwargs):
+    warnings.warn("register_recompile has been renamed to register_raw_precompile!")
+
+
+def register_raw_precompile(address, fn, force=False):
     global _precompiles
     address = _addr(address)
     if address in _precompiles and not force:
@@ -117,7 +122,7 @@ def register_precompile(address, fn, force=False):
     _precompiles[address] = fn
 
 
-def deregister_precompile(address, force=True):
+def deregister_raw_precompile(address, force=True):
     address = _addr(address)
     if address not in _precompiles and not force:
         raise ValueError("Not registered: {address}")
@@ -135,7 +140,7 @@ def console_log(computation):
 CONSOLE_ADDRESS = bytes.fromhex("000000000000000000636F6E736F6C652E6C6F67")
 
 
-register_precompile(CONSOLE_ADDRESS, console_log)
+register_raw_precompile(CONSOLE_ADDRESS, console_log)
 
 
 # a code stream which keeps a trace of opcodes it has executed

--- a/boa/precompile.py
+++ b/boa/precompile.py
@@ -104,9 +104,3 @@ def precompile(user_signature: str) -> Any:
         return wrapper
 
     return decorator
-
-
-@precompile("def printmsg(x: uint256, y: uint256) -> uint256")
-def printmsg(x: int, y: int) -> int:
-    print(x)
-    return x + y

--- a/boa/precompile.py
+++ b/boa/precompile.py
@@ -75,8 +75,7 @@ class PrecompileBuiltin(BuiltinFunction):
                     buf, # argsOffset
                     add_ofst(length, 4), # abi-encoded length + byte selector
                     buf, # overwrite argsOffset with result
-                    # self._return_type.size_bound() # return length
-                    32 # return length
+                    self._return_type.abi_type.size_bound() # return length
                     ])
         ret += [buf]
 

--- a/boa/precompile.py
+++ b/boa/precompile.py
@@ -75,6 +75,7 @@ class PrecompileBuiltin(BuiltinFunction):
                     buf, # argsOffset
                     add_ofst(length, 4), # abi-encoded length + byte selector
                     buf, # overwrite argsOffset with result
+                    # self._return_type.size_bound() # return length
                     32 # return length
                     ])
         ret += [buf]

--- a/boa/precompile.py
+++ b/boa/precompile.py
@@ -16,7 +16,7 @@ from vyper.semantics.types import TupleT
 from vyper.semantics.types.function import ContractFunctionT
 from vyper.utils import keccak256
 
-from boa.environment import register_precompile
+from boa.environment import register_raw_precompile
 
 
 class PrecompileBuiltin(BuiltinFunction):
@@ -88,7 +88,7 @@ def precompile(user_signature: str) -> Any:
                 return computation
 
         address = keccak256(user_signature.encode("utf-8"))[:20]
-        register_precompile(address, wrapper)
+        register_raw_precompile(address, wrapper)
 
         args = list(func_t.arguments.items())
         fn_name = func_t.name

--- a/boa/precompile.py
+++ b/boa/precompile.py
@@ -65,13 +65,13 @@ class PrecompileBuiltin(BuiltinFunction):
         # store abi-encoded argument at buf+4
         length = abi_encode(buf + 4, args_as_tuple, context, args_abi_t.size_bound(), returns_len=True)
 
-        MYPRINT_ADDRESS_STR = "0x" + str(self._address.hex().zfill(40))
-        MYPRINT_ADDRESS = int(MYPRINT_ADDRESS_STR, 16)
+        precompile_address_str = "0x" + str(self._address.hex().zfill(40))
+        precompile_address = int(precompile_address_str, 16)
 
         # call precompile
         ret.append(["staticcall",
                     "gas", # fwd all gas
-                    MYPRINT_ADDRESS, # precompile address
+                    precompile_address, # precompile address
                     buf, # argsOffset
                     add_ofst(length, 4), # abi-encoded length + byte selector
                     buf, # overwrite argsOffset with result

--- a/boa/precompile.py
+++ b/boa/precompile.py
@@ -1,122 +1,108 @@
-from typing import Optional
+from typing import Any
+
 from eth.codecs import abi
 from vyper.address_space import MEMORY
 from vyper.ast import parse_to_ast
-from vyper.codegen.core import IRnode
-from vyper.semantics.types.user import type_from_abi
-from vyper.semantics.types.utils import type_from_annotation
-from vyper.utils import binascii
-from boa.environment import register_precompile
-from vyper.builtins.functions import DISPATCH_TABLE, abi_encode, add_ofst, ir_tuple_from_args, process_inputs
 from vyper.builtins._signatures import BuiltinFunction
-from vyper.codegen.core import IRnode
-from vyper.semantics.types.shortcuts import (
-    UINT256_T,
+from vyper.builtins.functions import (
+    DISPATCH_TABLE,
+    STMT_DISPATCH_TABLE,
+    abi_encode,
+    ir_tuple_from_args,
+    process_inputs,
 )
+from vyper.codegen.core import IRnode, needs_external_call_wrap
+from vyper.semantics.types import ContractFunctionT, TupleT
+from vyper.utils import keccak256
 
-def extract_arg_types(signature: str):
-    # Extract argument types and their names using regex
+from boa.environment import register_precompile
 
-    args = signature.split("(")[1].split(")")[0].split(",")
-    typs = [x.split(":")[1].strip().split("[")[0].lower() for x in args]
-    names = [x.split(":")[0].strip().split("[")[0].lower() for x in args]
-
-    # Combine the cleaned argument types and return them in parentheses
-    return f"({','.join(typs)})", names
-
-def parse_address_string(address: str | bytes) -> bytes:
-    # Convert address string to bytes
-    if isinstance(address, str):
-        if address.startswith("0x"):
-            address = address[2:]
-        return bytes.fromhex(address)
-    elif isinstance(address, bytes):
-        return binascii.unhexlify(bytes(address.hex(), "utf-8").zfill(40))
 
 class PrecompileBuiltin(BuiltinFunction):
-    # id can be name
-    _id = ""
-    # list of inputs (parsed from signature)
-    _inputs = []
-    # return type (parsed from signature)
-    _return_type = None
-    _address = None
-
-    def __init__(self, name: str, inputs, return_type, address):
+    def __init__(self, name, args_type, return_type, address):
+        # override BuiltinFunction attributes
         self._id = name
-        self._inputs = inputs
+        self._inputs = args_type
         self._return_type = return_type
+
+        # set the precompile address
         self._address = address
 
     @process_inputs
     def build_IR(self, expr, args, kwargs, context):
         # allocate buffer for data to pass to precompile
         # we will pass 4-byte function selector and 32-byte argument
-        buf = context.new_internal_variable(self._return_type)
+        ret_buf = context.new_internal_variable(self._return_type)
 
         args_as_tuple = ir_tuple_from_args(args)
         args_abi_t = args_as_tuple.typ.abi_type
+        args_buf = context.new_internal_variable(args_as_tuple.typ)
 
         ret = ["seq"]
 
-        # store byte selector
-        ret += [["mstore", buf, 0x12341234]]
+        # store abi-encoded argument at buf
+        args_len = abi_encode(
+            args_buf, args_as_tuple, context, args_abi_t.size_bound(), returns_len=True
+        )
+        ret_len = self._return_type.abi_type.size_bound()
 
-        # store abi-encoded argument at buf+4
-        length = abi_encode(buf + 4, args_as_tuple, context, args_abi_t.size_bound(), returns_len=True)
-
-        precompile_address_str = "0x" + str(self._address.hex().zfill(40))
-        precompile_address = int(precompile_address_str, 16)
+        addr = int.from_bytes(self._address, "big")
 
         # call precompile
-        ret.append(["staticcall",
-                    "gas", # fwd all gas
-                    precompile_address, # precompile address
-                    buf, # argsOffset
-                    add_ofst(length, 4), # abi-encoded length + byte selector
-                    buf, # overwrite argsOffset with result
-                    self._return_type.abi_type.size_bound() # return length
-                    ])
-        ret += [buf]
+        ret.append(["staticcall", "gas", addr, args_buf, args_len, ret_buf, ret_len])
+        ret += [ret_buf]
 
         return IRnode.from_list(ret, typ=self._return_type, location=MEMORY)
 
-def precompile(signature: str, address: Optional[str | bytes] = None):
+
+# takes a user-provided signature and produces shim code for
+# serializing and deserializing
+# ex. precompile("def foo() -> uint256")
+def precompile(user_signature: str) -> Any:
     def decorator(func):
-        arg_types, names = extract_arg_types(signature)
-        typs = [type_from_abi({"type": x}) for x in arg_types[1:-1].split(",")]
-        inputs = list(zip(names, typs))
-        vy_ast = parse_to_ast(signature + ":\n\tpass")
-        return_type = type_from_annotation(vy_ast.body[0].returns)
-        output_signature = signature.split("->")[1].strip()
-        if not output_signature.startswith("("):
-            output_signature = f"({output_signature})"
+        vy_ast = parse_to_ast(user_signature + ":\n\tpass")
+        func_t = ContractFunctionT.from_FunctionDef(vy_ast, is_interface=True)
+        # TODO update once ContractFunctionT is refactored
+        args_t = TupleT(tuple(func_t.arguments.values()))
 
         def wrapper(computation):
             # Decode input arguments from message data
             message_data = computation.msg.data_as_bytes
-            input_args = abi.decode(arg_types, message_data[4:])
+            input_args = abi.decode(args_t, message_data)
 
             # Call the original function with decoded input arguments
-            result = func(*input_args)
+            res = func(*input_args)
 
-            # Encode the result to be ABI-compatible
-            # wrap output_signature in parentheses to make it a tuple if it's not already
-            computation.output = abi.encode(output_signature, [result])
+            return_t = func_t.return_type
+            if return_t is not None:
+                # Encode the result to be ABI-compatible
+                # wrap to make it a tuple if necessary
+                if needs_external_call_wrap(return_t):
+                    res = (res,)
+                    return_t = TupleT((return_t,))
 
-            # Register the precompile with the given address if one is provided
-            return computation
+                computation.output = abi.encode(return_t.abi_type.selector(), res)
 
-        if address:
-            register_precompile(parse_address_string(address), wrapper)
-            DISPATCH_TABLE["printmsg"] = PrecompileBuiltin("printmsg", inputs, return_type, address)
+                return computation
+
+        address = keccak256(user_signature)[:20]
+        register_precompile(address, wrapper)
+
+        builtin = PrecompileBuiltin(func_t.name, args_t, func_t.return_type, address)
+
+        # sketchy check to see which dispatch table it should go in
+        # ideally upstream vyper should be refactored to deal with this
+        if func_t.return_type is not None:
+            DISPATCH_TABLE[func_t.name] = builtin
+        else:
+            STMT_DISPATCH_TABLE[func_t.name] = builtin
 
         return wrapper
 
     return decorator
 
-@precompile("def printmsg(x: uint256, y: uint256) -> uint256", b'printuint256')
-def printmsg(x: int, y: int):
+
+@precompile("def printmsg(x: uint256, y: uint256) -> uint256")
+def printmsg(x: int, y: int) -> int:
     print(x)
     return x + y
-

--- a/boa/precompile.py
+++ b/boa/precompile.py
@@ -1,0 +1,122 @@
+from typing import Optional
+from eth.codecs import abi
+from vyper.address_space import MEMORY
+from vyper.ast import parse_to_ast
+from vyper.codegen.core import IRnode
+from vyper.semantics.types.user import type_from_abi
+from vyper.semantics.types.utils import type_from_annotation
+from vyper.utils import binascii
+from boa.environment import register_precompile
+from vyper.builtins.functions import DISPATCH_TABLE, abi_encode, add_ofst, ir_tuple_from_args, process_inputs
+from vyper.builtins._signatures import BuiltinFunction
+from vyper.codegen.core import IRnode
+from vyper.semantics.types.shortcuts import (
+    UINT256_T,
+)
+
+def extract_arg_types(signature: str):
+    # Extract argument types and their names using regex
+
+    args = signature.split("(")[1].split(")")[0].split(",")
+    typs = [x.split(":")[1].strip().split("[")[0].lower() for x in args]
+    names = [x.split(":")[0].strip().split("[")[0].lower() for x in args]
+
+    # Combine the cleaned argument types and return them in parentheses
+    return f"({','.join(typs)})", names
+
+def parse_address_string(address: str | bytes) -> bytes:
+    # Convert address string to bytes
+    if isinstance(address, str):
+        if address.startswith("0x"):
+            address = address[2:]
+        return bytes.fromhex(address)
+    elif isinstance(address, bytes):
+        return binascii.unhexlify(bytes(address.hex(), "utf-8").zfill(40))
+
+class PrecompileBuiltin(BuiltinFunction):
+    # id can be name
+    _id = ""
+    # list of inputs (parsed from signature)
+    _inputs = []
+    # return type (parsed from signature)
+    _return_type = None
+    _address = None
+
+    def __init__(self, name: str, inputs, return_type, address):
+        self._id = name
+        self._inputs = inputs
+        self._return_type = return_type
+        self._address = address
+
+    @process_inputs
+    def build_IR(self, expr, args, kwargs, context):
+        # allocate buffer for data to pass to precompile
+        # we will pass 4-byte function selector and 32-byte argument
+        buf = context.new_internal_variable(self._return_type)
+
+        args_as_tuple = ir_tuple_from_args(args)
+        args_abi_t = args_as_tuple.typ.abi_type
+
+        ret = ["seq"]
+
+        # store byte selector
+        ret += [["mstore", buf, 0x12341234]]
+
+        # store abi-encoded argument at buf+4
+        length = abi_encode(buf + 4, args_as_tuple, context, args_abi_t.size_bound(), returns_len=True)
+
+        MYPRINT_ADDRESS_STR = "0x" + str(self._address.hex().zfill(40))
+        MYPRINT_ADDRESS = int(MYPRINT_ADDRESS_STR, 16)
+
+        # call precompile
+        ret.append(["staticcall",
+                    "gas", # fwd all gas
+                    MYPRINT_ADDRESS, # precompile address
+                    buf, # argsOffset
+                    add_ofst(length, 4), # abi-encoded length + byte selector
+                    buf, # overwrite argsOffset with result
+                    32 # return length
+                    ])
+        ret += [buf]
+
+        return IRnode.from_list(ret, typ=self._return_type, location=MEMORY)
+
+def precompile(signature: str, address: Optional[str | bytes] = None):
+    def decorator(func):
+        arg_types, names = extract_arg_types(signature)
+        typs = [type_from_abi({"type": x}) for x in arg_types[1:-1].split(",")]
+        inputs = list(zip(names, typs))
+        vy_ast = parse_to_ast(signature + ":\n\tpass")
+        return_type = type_from_annotation(vy_ast.body[0].returns)
+        output_signature = signature.split("->")[1].strip()
+        if not output_signature.startswith("("):
+            output_signature = f"({output_signature})"
+
+        def wrapper(computation):
+            # Decode input arguments from message data
+            message_data = computation.msg.data_as_bytes
+            input_args = abi.decode(arg_types, message_data[4:])
+
+            # Call the original function with decoded input arguments
+            result = func(*input_args)
+
+            # Encode the result to be ABI-compatible
+            # wrap output_signature in parentheses to make it a tuple if it's not already
+            computation.output = abi.encode(output_signature, [result])
+
+            # Register the precompile with the given address if one is provided
+            return computation
+
+        if address:
+            register_precompile(parse_address_string(address), wrapper)
+            DISPATCH_TABLE["printmsg"] = PrecompileBuiltin("printmsg", inputs, return_type, address)
+
+        return wrapper
+
+    return decorator
+
+@precompile("def printmsg(x: uint256, y: uint256) -> uint256", b'printuint256')
+def printmsg(x: int, y: int):
+    print(x)
+    return x + y
+


### PR DESCRIPTION
# @precompile

fixes #38 

Implements a decorator that handles the abi encoding and decoding of precompile arguments and return values

## Usage:

```python
@boa.precompile("def huff(filename: String[128]) -> address")
def huff(filename: str):
    compilation_process = subprocess.run(["huffc", "-b", filename], capture_output=True)

    contract_address = boa.env.generate_address()
    contract_bytecode = binascii.unhexlify(compilation_process.stdout)
    boa.env.deploy_code(deploy_to=contract_address, bytecode=contract_bytecode)

    return contract_address

# currently these lines must still be handled manually, the decorator does not register the precompiles to an address
HUFF_PRECOMPILE_ADDRESS = bytes.fromhex("0000000000000000000000000000000068756666") # "huff" in bytes
register_precompile(HUFF_PRECOMPILE_ADDRESS, huff)
```

## Before the decorator
abi encoding and decoding had to be handled in the precompile definition
```python
def compile_huff_code(computation):
    message_data = computation.msg.data_as_bytes
    contract_data = abi.decode("(string)", message_data[4:])
    compilation_process = subprocess.run(["huffc", "-b", contract_data[0]], capture_output=True)

    contract_address = boa.env.generate_address()
    contract_bytecode = binascii.unhexlify(compilation_process.stdout)
    deployment_output = boa.env.deploy_code(deploy_to=contract_address, bytecode=contract_bytecode)

    computation.output = abi.encode("(address)", contract_address)
    return computation
```

TBD:
- Should the decorator also generate an address and call `register_precompile`❓🤨 We can generate the address by casting the function name to bytes (as is done with console.log), or it can be left to the user to handle
