### PR TITLE
fix: decoding of bytesM types

### DIFF
--- a/boa/__init__.py
+++ b/boa/__init__.py
@@ -1,6 +1,7 @@
 import contextlib
 import sys
 
+from boa.debugger import BoaDebug
 from boa.environment import (
     Env,
     deregister_precompile,
@@ -10,7 +11,6 @@ from boa.environment import (
 )
 from boa.interpret import BoaError, load, load_partial, loads, loads_partial
 from boa.vyper.contract import check_boa_error_matches
-from boa.debugger import BoaDebug
 
 # turn off tracebacks if we are in repl
 # https://stackoverflow.com/a/64523765

--- a/boa/debugger.py
+++ b/boa/debugger.py
@@ -2,6 +2,7 @@ import cmd
 
 from vyper.exceptions import VyperException
 
+
 class BoaDebug(cmd.Cmd):
     prompt = "(boa-debug) "
 
@@ -12,7 +13,7 @@ class BoaDebug(cmd.Cmd):
         self.contract._computation = computation
 
         ast_source = self.contract.find_source_of(computation.code)
-        if ast_source is not None:        
+        if ast_source is not None:
             print(VyperException("breakpoint at:", ast_source), file=self.stdout)
 
     def do_show_contract(self, *args):

--- a/boa/vyper/decoder_utils.py
+++ b/boa/vyper/decoder_utils.py
@@ -47,7 +47,7 @@ class ByteAddressableStorage:
 def decode_vyper_object(mem, typ):
     if isinstance(typ, BytesM_T):
         # TODO tag return value like `vyper_object` does
-        return mem[: typ._bytes_info.m].tobytes()
+        return mem[: typ.m_bits].tobytes()
     if isinstance(typ, AddressT):
         return to_checksum_address(mem[12:32].tobytes())
     if isinstance(typ, BoolT):


### PR DESCRIPTION
This small PR fixes the following error:

```
venv/lib/python3.10/site-packages/boa/vyper/contract.py:891: in __call__
    return self.contract.marshal_to_python(computation, typ)
venv/lib/python3.10/site-packages/boa/vyper/contract.py:620: in marshal_to_python
    self.handle_error(computation)
venv/lib/python3.10/site-packages/boa/vyper/contract.py:641: in handle_error
    raise BoaError(self.vyper_stack_trace(computation))
venv/lib/python3.10/site-packages/boa/vyper/contract.py:648: in vyper_stack_trace
    ret = StackTrace([ErrorDetail.from_computation(self, computation)])
venv/lib/python3.10/site-packages/boa/vyper/contract.py:175: in from_computation
    frame_detail = contract.debug_frame(computation)
venv/lib/python3.10/site-packages/boa/vyper/contract.py:522: in debug_frame
    frame_detail[k] = decode_vyper_object(mem.read(ofst, size), v.typ)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

mem = <memory at 0x1082725c0>, typ = bytes32

    def decode_vyper_object(mem, typ):
        if isinstance(typ, BytesM_T):
            # TODO tag return value like `vyper_object` does
>           return mem[: typ._bytes_info.m].tobytes()
E           AttributeError: 'BytesM_T' object has no attribute '_bytes_info'

venv/lib/python3.10/site-packages/boa/vyper/decoder_utils.py:50: AttributeError
```

This is because `vyper.semantics.types.primitives.BytesM_T` does not have `_bytes_info` anymore: https://github.com/vyperlang/vyper/blob/11a78eb5bb80e6ea8e65139845ec1bac34f62456/vyper/semantics/types/primitives.py#L51