### PR TITLE
Fix: fn node getter

### DIFF
--- a/boa/profiling.py
+++ b/boa/profiling.py
@@ -239,14 +239,11 @@ def cache_gas_used_for_computation(contract, computation):
     sum_net_gas = sum([i.net_gas for i in profile.profile.values()])
     sum_net_tot_gas = sum([i.net_tot_gas for i in profile.profile.values()])
 
-    try:
-        fn_name = contract._get_fn_from_computation(computation).name
-    except AttributeError:
-        # TODO: remove this once vyper PR 3202 is merged
-        # https://github.com/vyperlang/vyper/pull/3202
-        # and new vyper is released (so update vyper requirements
-        # in pyproject.toml)
+    fn = contract._get_fn_from_computation(computation)
+    if fn is None:
         fn_name = "unnamed"
+    else:
+        fn_name = fn.name
 
     fn = ContractMethodInfo(
         contract_name=contract_name,

--- a/boa/vyper/ast_utils.py
+++ b/boa/vyper/ast_utils.py
@@ -57,9 +57,16 @@ def get_fn_name_from_lineno(ast_map: dict, lineno: int) -> str:
     # TODO: this could be a performance bottleneck
     for source_map, node in ast_map.items():
         if source_map[0] == lineno:
-            if isinstance(node, vy_ast.FunctionDef):
-                return node.name
-            fn_node = node.get_ancestor(vy_ast.FunctionDef)
+            fn_node = get_fn_node_from_node(node)
             if fn_node:
                 return fn_node.name
     return ""
+
+
+def get_fn_node_from_node(node):
+
+    if isinstance(node, vy_ast.FunctionDef):
+        return node
+    fn_node = node.get_ancestor(vy_ast.FunctionDef)
+    if fn_node:
+        return fn_node

--- a/boa/vyper/ast_utils.py
+++ b/boa/vyper/ast_utils.py
@@ -65,8 +65,10 @@ def get_fn_name_from_lineno(ast_map: dict, lineno: int) -> str:
 
 def get_fn_node_from_node(node):
 
+    if node is None:
+        return None
+
     if isinstance(node, vy_ast.FunctionDef):
         return node
-    fn_node = node.get_ancestor(vy_ast.FunctionDef)
-    if fn_node:
-        return fn_node
+
+    return node.get_ancestor(vy_ast.FunctionDef)

--- a/boa/vyper/ast_utils.py
+++ b/boa/vyper/ast_utils.py
@@ -57,13 +57,13 @@ def get_fn_name_from_lineno(ast_map: dict, lineno: int) -> str:
     # TODO: this could be a performance bottleneck
     for source_map, node in ast_map.items():
         if source_map[0] == lineno:
-            fn_node = get_fn_node_from_node(node)
+            fn_node = get_fn_ancestor_from_node(node)
             if fn_node:
                 return fn_node.name
     return ""
 
 
-def get_fn_node_from_node(node):
+def get_fn_ancestor_from_node(node):
 
     if node is None:
         return None

--- a/boa/vyper/contract.py
+++ b/boa/vyper/contract.py
@@ -497,9 +497,7 @@ class VyperContract(_BaseContract):
 
     def _get_fn_from_computation(self, computation):
         node = self.find_source_of(computation.code)
-        fn_node = get_fn_ancestor_from_node(node)
-        if fn_node:
-            return fn_node
+        return get_fn_ancestor_from_node(node)
 
     def debug_frame(self, computation=None):
         if computation is None:

--- a/boa/vyper/contract.py
+++ b/boa/vyper/contract.py
@@ -35,7 +35,7 @@ from boa.util.exceptions import strip_internal_frames
 from boa.util.lrudict import lrudict
 from boa.vm.gas_meters import ProfilingGasMeter
 from boa.vyper import _METHOD_ID_VAR
-from boa.vyper.ast_utils import ast_map_of, get_fn_node_from_node, reason_at
+from boa.vyper.ast_utils import ast_map_of, get_fn_ancestor_from_node, reason_at
 from boa.vyper.compiler_utils import (
     _compile_vyper_function,
     generate_bytecode_for_arbitrary_stmt,
@@ -497,7 +497,7 @@ class VyperContract(_BaseContract):
 
     def _get_fn_from_computation(self, computation):
         node = self.find_source_of(computation.code)
-        fn_node = get_fn_node_from_node(node)
+        fn_node = get_fn_ancestor_from_node(node)
         if fn_node:
             return fn_node
 

--- a/boa/vyper/contract.py
+++ b/boa/vyper/contract.py
@@ -35,7 +35,7 @@ from boa.util.exceptions import strip_internal_frames
 from boa.util.lrudict import lrudict
 from boa.vm.gas_meters import ProfilingGasMeter
 from boa.vyper import _METHOD_ID_VAR
-from boa.vyper.ast_utils import ast_map_of, reason_at
+from boa.vyper.ast_utils import ast_map_of, get_fn_node_from_node, reason_at
 from boa.vyper.compiler_utils import (
     _compile_vyper_function,
     generate_bytecode_for_arbitrary_stmt,
@@ -497,15 +497,18 @@ class VyperContract(_BaseContract):
 
     def _get_fn_from_computation(self, computation):
         node = self.find_source_of(computation.code)
-        if isinstance(node, vy_ast.FunctionDef):
-            return node
-        return node.get_ancestor(vy_ast.FunctionDef)
+        fn_node = get_fn_node_from_node(node)
+        if fn_node:
+            return fn_node
 
     def debug_frame(self, computation=None):
         if computation is None:
             computation = self._computation
 
         fn = self._get_fn_from_computation(computation)
+        if fn is None:
+            # TODO: figure out why fn is None.
+            return None
 
         frame_info = self.compiler_data.function_signatures[fn.name].frame_info
 


### PR DESCRIPTION
This PR applies a band-aid patch to the following error:

```

    @given(
>       dx=strategy("uint256", min_value=10**10, max_value=100 * 10**18),
        j=strategy("uint8", min_value=0, max_value=1),
    )

tests/unitary/pool/test_callback.py:42: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
venv/lib/python3.10/site-packages/boa/test/plugin.py:23: in f
    t(*args, **kwargs)
tests/unitary/pool/test_callback.py:51: in test_revert_good_callback_input_eth
    zap.good_exchange(2, j, dx, 0, True, value=dx)
venv/lib/python3.10/site-packages/boa/vyper/contract.py:894: in __call__
    return self.contract.marshal_to_python(computation, typ)
venv/lib/python3.10/site-packages/boa/vyper/contract.py:623: in marshal_to_python
    self.handle_error(computation)
venv/lib/python3.10/site-packages/boa/vyper/contract.py:644: in handle_error
    raise BoaError(self.vyper_stack_trace(computation))
venv/lib/python3.10/site-packages/boa/vyper/contract.py:651: in vyper_stack_trace
    ret = StackTrace([ErrorDetail.from_computation(self, computation)])
venv/lib/python3.10/site-packages/boa/vyper/contract.py:175: in from_computation
    frame_detail = contract.debug_frame(computation)
venv/lib/python3.10/site-packages/boa/vyper/contract.py:508: in debug_frame
    fn = self._get_fn_from_computation(computation)
venv/lib/python3.10/site-packages/boa/vyper/contract.py:500: in _get_fn_from_computation
    fn_node = get_fn_node_from_node(node)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

node = None

    def get_fn_node_from_node(node):
    
        if isinstance(node, vy_ast.FunctionDef):
            return node
>       fn_node = node.get_ancestor(vy_ast.FunctionDef)
E       AttributeError: 'NoneType' object has no attribute 'get_ancestor'
```