### PR TITLE
Fix StackOverflow When Running Coverage

### DIFF
--- a/boa/environment.py
+++ b/boa/environment.py
@@ -572,8 +572,9 @@ class Env:
             # loop over pc so that it is available when coverage hooks into it
             pass
         for child in computation.children:
-            child_contract = self.lookup_contract(child.msg.code_address)
-            self._hook_trace_computation(computation, child_contract)
+            if child.msg.code_address != b'':
+                child_contract = self.lookup_contract(child.msg.code_address)
+                self._hook_trace_computation(child, child_contract)
 
     # function to time travel
     def time_travel(


### PR DESCRIPTION
When running coverage in complex scenarios the stack will overflow with a stdout similar to
```
File "/Users/controlc/Library/Caches/pypoetry/virtualenvs/minimal-repro-NwtGl1oq-py3.10/lib/python3.10/site-packages/boa/environment.py", line 576 in _hook_trace_computation
  File "/Users/controlc/Library/Caches/pypoetry/virtualenvs/minimal-repro-NwtGl1oq-py3.10/lib/python3.10/site-packages/boa/environment.py", line 576 in _hook_trace_computation
  File "/Users/controlc/Library/Caches/pypoetry/virtualenvs/minimal-repro-NwtGl1oq-py3.10/lib/python3.10/site-packages/boa/environment.py", line 576 in _hook_trace_computation
```

Upon investigation I found 2 potential culprits, first being 
`child_contract` in the hook_trace function can sometimes be empty bytes resulting in this format error for the contract ` ValueError: Unknown format b'', attempted to normalize to '0x'`, additionally, the original `computation` value is passed into the function, resulting in an infinite recursion leading the stackoverflow above, and `child` should be passed in instead so that the call will eventually terminate

First time writing serious python code so lmk if I pissed anything, but I've tested the fix locally one of my more complex repos and it appears to work