### PR TITLE
Avoid KeyError for unspecified ABI traces

### DIFF
--- a/boa/vyper/contract.py
+++ b/boa/vyper/contract.py
@@ -1102,10 +1102,15 @@ class ABIContract(VyperContract):
     def stack_trace(self, computation=None):
         computation = computation or self._computation
         calldata_method_id = bytes(computation.msg.data[:4])
-        # when the method isn't specified in the ABI, it's not present in the map
-        abi_sig = self.method_id_map.get(calldata_method_id, f"({calldata_method_id})")
-        ret = StackTrace([f"  (unknown location in {self}.{abi_sig})"])
-        return _handle_child_trace(computation, self.env, ret)
+        return_trace = StackTrace(
+            [
+                f"  (unknown location in {self}.{self.method_id_map[calldata_method_id]})"
+                if calldata_method_id in self.method_id_map
+                # Method might not be specified in the ABI
+                else f"  (unknown method {calldata_method_id} in {self})"
+            ]
+        )
+        return _handle_child_trace(computation, self.env, return_trace)
 
     @property
     def deployer(self):

--- a/boa/vyper/contract.py
+++ b/boa/vyper/contract.py
@@ -1103,7 +1103,7 @@ class ABIContract(VyperContract):
         computation = computation or self._computation
         calldata_method_id = bytes(computation.msg.data[:4])
         # when the method isn't specified in the ABI, it's not present in the map
-        abi_sig = self.method_id_map.get(calldata_method_id, "?")
+        abi_sig = self.method_id_map.get(calldata_method_id, f"({calldata_method_id})")
         ret = StackTrace([f"  (unknown location in {self}.{abi_sig})"])
         return _handle_child_trace(computation, self.env, ret)
 

--- a/boa/vyper/contract.py
+++ b/boa/vyper/contract.py
@@ -1102,7 +1102,8 @@ class ABIContract(VyperContract):
     def stack_trace(self, computation=None):
         computation = computation or self._computation
         calldata_method_id = bytes(computation.msg.data[:4])
-        abi_sig = self.method_id_map[calldata_method_id]
+        # when the method isn't specified in the ABI, it's not present in the map
+        abi_sig = self.method_id_map.get(calldata_method_id, "?")
         ret = StackTrace([f"  (unknown location in {self}.{abi_sig})"])
         return _handle_child_trace(computation, self.env, ret)
 


### PR DESCRIPTION
If an error is raised in a method not specified in the ABI, boa currently crashes with a KeyError.
Instead of crashing we can still provide some stack trace for the user without a method name.

Given https://github.com/vyperlang/titanoboa/issues/106 it's sometimes currently not possible to include a full ABI.