### PR TITLE
Fix pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,26 +2,28 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
-  - repo: https://github.com/psf/black
-    rev: 22.3.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.12.0
     hooks:
       - id: black
         args:
-          - -C
-          - --target-version=py38
+          - --skip-magic-trailing-comma
+          - --target-version=py310
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.9.2
+    rev: 6.1.0
     hooks:
       - id: flake8
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.10.1
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
     hooks:
       - id: isort
+        # profile and line-length to avoid clashes with black
+        args: ["--profile=black", "--line-length=88"]
 
 default_language_version:
   python: python3.10

--- a/boa/network.py
+++ b/boa/network.py
@@ -10,7 +10,15 @@ from eth_account import Account
 from requests.exceptions import HTTPError
 
 from boa.environment import Address, Env
-from boa.rpc import EthereumRPC, RPCError, fixup_dict, to_bytes, to_hex, to_int, trim_dict
+from boa.rpc import (
+    EthereumRPC,
+    RPCError,
+    fixup_dict,
+    to_bytes,
+    to_hex,
+    to_int,
+    trim_dict,
+)
 
 
 class TraceObject:

--- a/docs/source/coverage.rst
+++ b/docs/source/coverage.rst
@@ -11,9 +11,9 @@ To use, add the following to ``.coveragerc``:
     plugins = boa.coverage
 
 (for more information see https://coverage.readthedocs.io/en/latest/config.html)
- 
+
 Then, run with ``coverage run ...``
- 
+
 To run with pytest, it can be invoked in either of two ways,
 
 .. code-block::
@@ -29,6 +29,5 @@ or,
 `pytest-cov <https://pytest-cov.readthedocs.io/en/latest/readme.html#usage>`_ is a wrapper around ``coverage.py`` for using with pytest; using it is recommended because it smooths out some quirks of using ``coverage.py`` with pytest.
 
 Finally, ``coverage.py`` saves coverage data to a file named ``.coverage`` in the directory it is run in. To view the formatted coverage data, you typically want to use ``coverage report`` or ``coverage html``. See more options at https://coverage.readthedocs.io/en/latest/cmd.html.
- 
-Coverage is experimental and there may be odd corner cases! If so, please report them on github or in the ``#titanoboa-interpreter`` channel of the `Vyper discord <https://discord.gg/6tw7PTM7C2>`_.
 
+Coverage is experimental and there may be odd corner cases! If so, please report them on github or in the ``#titanoboa-interpreter`` channel of the `Vyper discord <https://discord.gg/6tw7PTM7C2>`_.


### PR DESCRIPTION
There is a conflict between `black` and `isort` that is causing pre-commit hooks to always fail
`black` changes the file and `isort` changes it back to the original. The result is the hook fails and the code is not changed.

In this PR I updated the pre-commit config to the latest versions and changed the `isort` line length to match what `black` expects