### PR TITLE
fix debug frames for uninitialized variables

### DIFF
--- a/boa/vyper/decoder_utils.py
+++ b/boa/vyper/decoder_utils.py
@@ -85,10 +85,12 @@ def decode_vyper_object(mem, typ):
     if isinstance(typ, DArrayT):
         length = _get_length(mem[:32], typ.length)
         n = typ.subtype.memory_bytes_required
-        return [
-            decode_vyper_object(mem[offset : offset + n], typ.subtype)
-            for offset in range(32, 32 + length * n, n)
-        ]
+        ofst = 32
+        ret = []
+        for _ in range(length):
+            ret.append(decode_vyper_object(mem[ofst : ofst + n], typ.subtype))
+            ofst += n
+        return ret
     if isinstance(typ, StructT):
         ret = _Struct(typ.name)
         ofst = 0

--- a/boa/vyper/decoder_utils.py
+++ b/boa/vyper/decoder_utils.py
@@ -68,7 +68,7 @@ def decode_vyper_object(mem, typ):
     if isinstance(typ, (BytesT, StringT, DArrayT)):
         length = int.from_bytes(mem[:32], "big")
         if length > typ.length:
-            return None  # array uninitialized; bail to avoid performance issues
+            length = 0  # array uninitialized; pretend it is empty for performance
 
         if isinstance(typ, DArrayT):
             n = typ.subtype.memory_bytes_required

--- a/boa/vyper/decoder_utils.py
+++ b/boa/vyper/decoder_utils.py
@@ -53,7 +53,10 @@ class _Struct(dict):
 def _get_length(mem, bound):
     ret = int.from_bytes(mem[:32], "big")
     if ret > bound:
-        return bound + 1 # uninitialized variable; fill with garbage
+        # perf -- this is an uninitialized variable; length and data are
+        # both garbage. truncate length to the bound of the container of
+        # this type. the data will still be garbage, but we avoid OOM.
+        return bound
     return ret
 
 def decode_vyper_object(mem, typ):

--- a/boa/vyper/decoder_utils.py
+++ b/boa/vyper/decoder_utils.py
@@ -71,10 +71,10 @@ def decode_vyper_object(mem, typ):
         return ret
     if isinstance(typ, BytesT):
         length = _get_length(mem[:32], typ.length)
+        return mem[32 : 32 + length].tobytes()
     if isinstance(typ, StringT):
         length = _get_length(mem[:32], typ.length)
         return mem[32 : 32 + length].tobytes().decode("utf-8")
-        return mem[32 : 32 + length].tobytes()
     if isinstance(typ, SArrayT):
         length = typ.count
         n = typ.subtype.memory_bytes_required

--- a/boa/vyper/decoder_utils.py
+++ b/boa/vyper/decoder_utils.py
@@ -69,11 +69,11 @@ def decode_vyper_object(mem, typ):
         if typ.is_signed:
             return unsigned_to_signed(ret, 256)
         return ret
+    if isinstance(typ, BytesT):
+        length = _get_length(mem[:32], typ.length)
     if isinstance(typ, StringT):
         length = _get_length(mem[:32], typ.length)
         return mem[32 : 32 + length].tobytes().decode("utf-8")
-    if isinstance(typ, BytesT):
-        length = _get_length(mem[:32], typ.length)
         return mem[32 : 32 + length].tobytes()
     if isinstance(typ, SArrayT):
         length = typ.count

--- a/boa/vyper/decoder_utils.py
+++ b/boa/vyper/decoder_utils.py
@@ -84,6 +84,8 @@ def decode_vyper_object(mem, typ):
         ]
     if isinstance(typ, DArrayT):
         length = int.from_bytes(mem[:32], "big")
+        if length > typ.length:
+            return []  # array is not initialized yet, memory can have garbage
         n = typ.subtype.memory_bytes_required
         ofst = 32
         ret = []

--- a/tests/unitary/test_reverts.py
+++ b/tests/unitary/test_reverts.py
@@ -117,9 +117,11 @@ def test_compiler_reason_does_not_stop_dev_reason(contract):
             contract.bar(3)
 
 
-@pytest.mark.parametrize("type_", ["DynArray[uint8, 8]", "String[8]", "Bytes[8]"])
-def test_variable_not_initialized_when_error(type_):
-    contract = boa.loads(
+@pytest.mark.parametrize(
+    "type_,expected", [("DynArray[uint8, 8]", []), ("String[8]", ""), ("Bytes[8]", b"")]
+)
+def test_variable_not_initialized_when_error(type_, expected):
+    c = boa.loads(
         f"""
 struct Test:
     data: {type_}
@@ -133,7 +135,7 @@ def foo(x: uint8):
     """
     )
     with pytest.raises(BoaError) as error_context:
-        contract.foo(1)
+        c.foo(1)
 
     frame = error_context.value.args[0].last_frame
-    assert frame.frame_detail["uninitialized"] is None
+    assert frame.frame_detail["uninitialized"] == expected


### PR DESCRIPTION
### What I did
I experienced issues when boa tried to print debug frames before a specific dyn array is initialized.
The memory might contain a very large length, which causes boa to loop forever.

### How I did it
I created a minimal reproduction in unit test and fixed it by handling unexpected array lengths.

### How to verify it
Tests included

### Description for the changelog
Fix endless loops when debugging uninitialized variables

### Cute Animal Picture
![image](https://github.com/vyperlang/titanoboa/assets/2369243/d5099f0f-a4ef-4ae5-a41c-2b8701db3ed8)

