### PR TITLE
Fix/blockidentifier

### DIFF
--- a/boa/vm/fork.py
+++ b/boa/vm/fork.py
@@ -117,7 +117,13 @@ class AccountDBFork(AccountDB):
         block_identifier = rpc_kwargs.pop("block_identifier", "safe")
         self._rpc = CachingRPC.get_rpc(**rpc_kwargs)
 
-        if block_identifier not in ("safe", "latest", "finalized", "pending", "earliest"):
+        if block_identifier not in (
+            "safe",
+            "latest",
+            "finalized",
+            "pending",
+            "earliest",
+        ):
             block_identifier = to_hex(block_identifier)
 
         # do not cache - use raw_fetch

--- a/boa/vm/fork.py
+++ b/boa/vm/fork.py
@@ -117,7 +117,7 @@ class AccountDBFork(AccountDB):
         block_identifier = rpc_kwargs.pop("block_identifier", "safe")
         self._rpc = CachingRPC.get_rpc(**rpc_kwargs)
 
-        if block_identifier not in ("safe", "latest", "finalized"):
+        if block_identifier not in ("safe", "latest", "finalized", "pending", "earliest"):
             block_identifier = to_hex(block_identifier)
 
         # do not cache - use raw_fetch

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -445,7 +445,7 @@ Low-Level Functionality
         Fork the state of an external node allowing local simulation of state mutations.
 
         :param provider: The URL of the node provider to fork the state of.
-        :param block_identifier: The block identifier to fork the state at.
+        :param block_identifier: The block identifier to fork the state at. The value may be an integer, bytes, an hexadecimal string or a pre-defined block identifier (``"earliest"`` , ``"latest"``, ``"pending"``, ``"safe"`` or ``"finalized"``). Defaults to ``"safe"``.
 
         .. rubric:: Example
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -445,7 +445,7 @@ Low-Level Functionality
         Fork the state of an external node allowing local simulation of state mutations.
 
         :param provider: The URL of the node provider to fork the state of.
-        :param block_identifier: The block identifier to fork the state at. The value may be an integer, bytes, an hexadecimal string or a pre-defined block identifier (``"earliest"`` , ``"latest"``, ``"pending"``, ``"safe"`` or ``"finalized"``). Defaults to ``"safe"``.
+        :param block_identifier: The block identifier to fork the state at. The value may be an integer, bytes, a hexadecimal string or a pre-defined block identifier (``"earliest"`` , ``"latest"``, ``"pending"``, ``"safe"`` or ``"finalized"``). Defaults to ``"safe"``.
 
         .. rubric:: Example
 


### PR DESCRIPTION
### What I did

- Added the possibility to specify `"pending"` and "`earliest`" as pre-defined block identifiers when using `boa.env.fork`. 
- Updated the documentation.

### Description for the changelog

Add support for "pending" and "earliest" pre-defined block identifiers

