### PR TITLE
Display storage dump with state before revert

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,6 +1,6 @@
 name: unitary
 
-on: ["push"]
+on: ["push", "pull_request"]
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -55,7 +55,6 @@ jobs:
       # XXX: are these actually unit tests?
       - name: Run Fork Mode Tests
         run: pytest -n auto tests/integration/fork/
-        if: secrets.ALCHEMY_MAINNET_ENDPOINT
         env:
           MAINNET_ENDPOINT: ${{ secrets.ALCHEMY_MAINNET_ENDPOINT }}
 
@@ -66,7 +65,6 @@ jobs:
       - name: Run Sepolia Tests
         # disable xdist, otherwise they can contend for tx nonce
         run: pytest -n 0 tests/integration/network/sepolia/
-        if: secrets.SEPOLIA_PKEY
         env:
           SEPOLIA_ENDPOINT: ${{ secrets.ALCHEMY_SEPOLIA_ENDPOINT }}
           SEPOLIA_PKEY: ${{ secrets.SEPOLIA_PKEY }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,6 +1,6 @@
 name: unitary
 
-on: ["push", "pull_request"]
+on: ["push"]
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -55,6 +55,7 @@ jobs:
       # XXX: are these actually unit tests?
       - name: Run Fork Mode Tests
         run: pytest -n auto tests/integration/fork/
+        if: secrets.ALCHEMY_MAINNET_ENDPOINT
         env:
           MAINNET_ENDPOINT: ${{ secrets.ALCHEMY_MAINNET_ENDPOINT }}
 
@@ -65,6 +66,7 @@ jobs:
       - name: Run Sepolia Tests
         # disable xdist, otherwise they can contend for tx nonce
         run: pytest -n 0 tests/integration/network/sepolia/
+        if: secrets.SEPOLIA_PKEY
         env:
           SEPOLIA_ENDPOINT: ${{ secrets.ALCHEMY_SEPOLIA_ENDPOINT }}
           SEPOLIA_PKEY: ${{ secrets.SEPOLIA_PKEY }}

--- a/boa/environment.py
+++ b/boa/environment.py
@@ -311,6 +311,7 @@ class titanoboa_computation:
             self._gas_meter._set_code(self.code)
 
         self._child_pcs = []
+        self._contract_repr_before_revert = None
 
     def add_child_computation(self, child_computation):
         super().add_child_computation(child_computation)
@@ -348,7 +349,7 @@ class titanoboa_computation:
             if computation.is_error:
                 # After the computation is applied with an error the state is reverted
                 # Before the revert, save the contract representation for the error message
-                setattr(computation, "_boa_contract_repr_before_revert", repr(contract))
+                computation._contract_repr_before_revert = repr(contract)
             return computation
 
         with cls(state, msg, tx_ctx) as computation:
@@ -371,7 +372,7 @@ class titanoboa_computation:
         return computation
 
     def get_contract_repr(self, contract):
-        return getattr(self, "_boa_contract_repr_before_revert", None) or repr(contract)
+        return self._contract_repr_before_revert or repr(contract)
 
 
 # Message object with extra attrs we can use to thread things through

--- a/boa/vyper/contract.py
+++ b/boa/vyper/contract.py
@@ -196,7 +196,7 @@ class DevReason:
 @dataclass
 class ErrorDetail:
     vm_error: VMError
-    contract: "VyperContract"
+    contract_repr: str  # string representation of the contract for the error
     error_detail: str  # compiler provided error detail
     dev_reason: DevReason
     frame_detail: FrameDetail
@@ -217,7 +217,7 @@ class ErrorDetail:
 
         return cls(
             vm_error=computation.error,
-            contract=contract,
+            contract_repr=computation.get_contract_repr(contract),
             error_detail=error_detail,
             dev_reason=reason,
             frame_detail=frame_detail,
@@ -235,7 +235,7 @@ class ErrorDetail:
         return repr(err)
 
     def __str__(self):
-        msg = f"{self.contract}\n"
+        msg = f"{self.contract_repr}\n"
 
         if self.error_detail is not None:
             msg += f" <compiler: {self.error_detail}>"

--- a/boa/vyper/contract.py
+++ b/boa/vyper/contract.py
@@ -215,9 +215,10 @@ class ErrorDetail:
             )
         frame_detail = contract.debug_frame(computation)
 
+        contract_repr = computation._contract_repr_before_revert or repr(contract)
         return cls(
             vm_error=computation.error,
-            contract_repr=computation.get_contract_repr(contract),
+            contract_repr=contract_repr
             error_detail=error_detail,
             dev_reason=reason,
             frame_detail=frame_detail,

--- a/boa/vyper/contract.py
+++ b/boa/vyper/contract.py
@@ -218,7 +218,7 @@ class ErrorDetail:
         contract_repr = computation._contract_repr_before_revert or repr(contract)
         return cls(
             vm_error=computation.error,
-            contract_repr=contract_repr
+            contract_repr=contract_repr,
             error_detail=error_detail,
             dev_reason=reason,
             frame_detail=frame_detail,

--- a/boa/vyper/decoder_utils.py
+++ b/boa/vyper/decoder_utils.py
@@ -50,6 +50,7 @@ class _Struct(dict):
     def __repr__(self):
         return f"{self.struct_name}({super().__repr__()})"
 
+
 def _get_length(mem, bound):
     ret = int.from_bytes(mem[:32], "big")
     if ret > bound:
@@ -58,6 +59,7 @@ def _get_length(mem, bound):
         # this type. the data will still be garbage, but we avoid OOM.
         return bound
     return ret
+
 
 def decode_vyper_object(mem, typ):
     if isinstance(typ, BytesM_T):

--- a/tests/unitary/test_reverts.py
+++ b/tests/unitary/test_reverts.py
@@ -144,3 +144,22 @@ def foo(x: uint8):
     assert frame.frame_detail["uninitialized"] != empty
     # check the frame is always bounded properly.
     assert len(frame.frame_detail["uninitialized"]) == 8
+
+
+def test_revert_check_storage():
+    c = boa.loads(
+        """
+counter: public(uint256)
+@external
+def add():
+    self.counter += 1
+    assert self.counter == 0
+    """
+    )
+    try:
+        assert c.add()
+    except BoaError as e:
+        assert "<storage: counter=1>" in str(e)
+
+    assert 0 == c._storage.counter.get()
+    assert 0 == c.counter()


### PR DESCRIPTION
### What I did
- Save the contract `repr` with the computation in case of an error
- Use this value to show the storage state when the computation errored
- This should fix #92

### How I did it
- Investigated how py-evm handles the snapshots
  - However, the data gets completely deleted after revert. To save all the [deleted data](https://github.com/ethereum/py-evm/blob/d625109bd92ab9a811c9ab64d375448b3fe7aecf/eth/db/account.py#L438-L444) would be quite cumbersome
- Instead of saving the whole journal, it makes more sense to only save the data we need when we need it
- Therefore I only extract the `repr(contract)` before the revert, as this is the information used
- Alternatively we could extract more data at this point (e.g. `storage.dump()`)
- The implementation is in the `environment` as this is specific to py-evm

### How to verify it
- Test is included; Please advise on extra test/corner cases that I did not identify.

### Description for the changelog
- Display the storage dump with the state before the computation was reverted

### Cute Animal Picture
![image](https://github.com/vyperlang/titanoboa/assets/2369243/d0e3345e-b52d-4604-83e0-a4bbaaf16d74)
