### PR TITLE
Sign typed data using BrowserSigner

### DIFF
--- a/boa/integrations/jupyter/browser.py
+++ b/boa/integrations/jupyter/browser.py
@@ -66,6 +66,24 @@ class BrowserSigner:
         )
         return convert_frontend_dict(sign_data)
 
+    def sign_typed_data(
+        self, domain: dict[str, Any], types: dict[str, list], value: dict[str, Any]
+    ) -> str:
+        """
+        Sign typed data value with types data structure for domain using the EIP-712 specification.
+        :param domain: The domain data structure.
+        :param types: The types data structure.
+        :param value: The value to sign.
+        :return: The signature.
+        """
+        return _javascript_call(
+            "signTypedData",
+            domain,
+            types,
+            value,
+            timeout_message=TRANSACTION_TIMEOUT_MESSAGE,
+        )
+
 
 class BrowserRPC(RPC):
     """

--- a/boa/integrations/jupyter/jupyter.js
+++ b/boa/integrations/jupyter/jupyter.js
@@ -40,17 +40,16 @@
         return response.text();
     }
 
+    const getSigner = () => getEthersProvider().getSigner();
+
     /** Load the signer via ethers user */
-    const loadSigner = async () => {
-        const signer = await getEthersProvider().getSigner();
-        return signer.getAddress();
-    };
+    const loadSigner = () => getSigner().then(s => s.getAddress());
 
     /** Sign a transaction via ethers */
-    async function signTransaction(transaction) {
-        const signer = await getEthersProvider().getSigner();
-        return signer.sendTransaction(transaction);
-    }
+    const signTransaction = transaction => getSigner().then(s => s.signTransaction(transaction));
+
+    /** Sign a typed data via ethers */
+    const signTypedData = (domain, types, value) => getSigner().then(s => s.signTypedData(domain, types, value));
 
     /** Call an RPC method via ethers */
     const rpc = (method, params) => getEthersProvider().send(method, params);
@@ -91,6 +90,7 @@
     window._titanoboa = {
         loadSigner: handleCallback(loadSigner),
         signTransaction: handleCallback(signTransaction),
+        signTypedData: handleCallback(signTypedData),
         waitForTransactionReceipt: handleCallback(waitForTransactionReceipt),
         rpc: handleCallback(rpc),
         multiRpc: handleCallback(multiRpc),

--- a/tests/unitary/jupyter/test_browser.py
+++ b/tests/unitary/jupyter/test_browser.py
@@ -6,7 +6,6 @@ from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import pytest
-from eth_account import Account
 
 import boa
 
@@ -124,6 +123,7 @@ def mock_fork(mock_callback):
 
 @pytest.fixture()
 def browser(nest_asyncio_mock, jupyter_module_mock):
+    # Import the browser module after the mocks have been set up
     from boa.integrations.jupyter import browser
 
     return browser
@@ -131,7 +131,7 @@ def browser(nest_asyncio_mock, jupyter_module_mock):
 
 @pytest.fixture()
 def account():
-    return Account.create()
+    return boa.env.generate_address()
 
 
 @pytest.fixture()
@@ -150,6 +150,16 @@ def test_browser_signer_given_address(browser, display_mock, mock_inject_javascr
     assert signer.address == "0x1234"
     display_mock.assert_not_called()
     mock_inject_javascript.assert_not_called()
+
+
+def test_browser_sign_typed_data(
+    browser, display_mock, mock_inject_javascript, mock_callback
+):
+    signer = browser.BrowserSigner(boa.env.generate_address())
+    signature = boa.env.generate_address()
+    mock_callback("signTypedData", signature)
+    data = signer.sign_typed_data({"name": "My App"}, {"types": []}, {"data": "0x1234"})
+    assert data == signature
 
 
 def test_browser_signer_no_address(

--- a/tests/unitary/jupyter/test_browser.py
+++ b/tests/unitary/jupyter/test_browser.py
@@ -6,6 +6,7 @@ from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import pytest
+from eth_account import Account
 
 import boa
 
@@ -131,7 +132,7 @@ def browser(nest_asyncio_mock, jupyter_module_mock):
 
 @pytest.fixture()
 def account():
-    return boa.env.generate_address()
+    return Account.create()
 
 
 @pytest.fixture()


### PR DESCRIPTION
Closes #128
~~Depends on https://github.com/vyperlang/titanoboa/pull/124~~

### What I did
Allow signing typed data using BrowserSigner

### How I did it
- Created the `sign_typed_data` method in the BrowserSigner.
- Created the `signTypedData` front-end callback
- Added a test

### How to verify it
Try in a notebook:
```
!pip install git+https://github.com/DanielSchiavini/titanoboa.git@128/sign-typed-data
from boa.integrations.jupyter import BrowserSigner
BrowserSigner().sign_typed_data(....)
```

### Description for the changelog
Allow signing typed data in JupyterLab/Colab using BrowserSigner

### Cute Animal Picture
![image](https://github.com/vyperlang/titanoboa/assets/2369243/d24eedbb-3bcf-4bf9-84f8-7e0f749c7e89)

