### PR TITLE
Use sendTransaction instead of signTransaction

### DIFF
--- a/boa/integrations/jupyter/browser.py
+++ b/boa/integrations/jupyter/browser.py
@@ -65,7 +65,7 @@ class BrowserSigner:
         :return: The signed transaction data.
         """
         sign_data = _javascript_call(
-            "signTransaction", tx_data, timeout_message=TRANSACTION_TIMEOUT_MESSAGE
+            "sendTransaction", tx_data, timeout_message=TRANSACTION_TIMEOUT_MESSAGE
         )
         return convert_frontend_dict(sign_data)
 

--- a/boa/integrations/jupyter/jupyter.js
+++ b/boa/integrations/jupyter/jupyter.js
@@ -46,7 +46,7 @@
     const loadSigner = () => getSigner().then(s => s.getAddress());
 
     /** Sign a transaction via ethers */
-    const signTransaction = transaction => getSigner().then(s => s.signTransaction(transaction));
+    const sendTransaction = transaction => getSigner().then(s => s.sendTransaction(transaction));
 
     /** Sign a typed data via ethers */
     const signTypedData = (domain, types, value) => getSigner().then(s => s.signTypedData(domain, types, value));
@@ -55,15 +55,15 @@
     const rpc = (method, params) => getEthersProvider().send(method, params);
 
     /** Wait until the transaction is mined */
-    const waitForTransactionReceipt = async (params, timeout, poll_latency) => {
+    const waitForTransactionReceipt = async (tx_hash, timeout, poll_latency) => {
         while (true) {
             try {
-                const result = await rpc('eth_getTransactionReceipt', params);
+                const result = await rpc('eth_getTransactionReceipt', [tx_hash]);
                 if (result) {
                     return result;
                 }
             } catch (err) { // ignore "server error" (happens while transaction is mined)
-                if (err?.info?.error?.code !== -32603) {
+                if ((err?.info || err)?.error?.code !== -32603) {
                     throw err;
                 }
             }
@@ -94,7 +94,7 @@
     // expose functions to window, so they can be called from the BrowserSigner
     window._titanoboa = {
         loadSigner: handleCallback(loadSigner),
-        signTransaction: handleCallback(signTransaction),
+        sendTransaction: handleCallback(sendTransaction),
         signTypedData: handleCallback(signTypedData),
         waitForTransactionReceipt: handleCallback(waitForTransactionReceipt),
         rpc: handleCallback(rpc),


### PR DESCRIPTION
### What I did
Changed the browser signer to use sendTransaction instead of signTransaction.
The send transaction is [not supported](https://github.com/DanielSchiavini/titanoboa/blob/6d67bda184b257bf3c79d4a19f8b74929ac4a8d8/boa/network.py#L414) on metamask.

### How I did it
- Changed the JS call
- Added the tx_hash to an array to call getTransactionReceipt

### How to verify it
- Deploy a contract with metamask

### Description for the changelog
- Added support to sign transactions in metamask

### Cute Animal Picture
![image](https://github.com/vyperlang/titanoboa/assets/2369243/5a81f80f-28e3-42fb-921c-632ed398f0a0)
