### PR TITLE
Do not trigger wallet on page reload

### DIFF
--- a/boa/integrations/jupyter/handlers.py
+++ b/boa/integrations/jupyter/handlers.py
@@ -22,7 +22,20 @@ class CallbackHandler(APIHandler):
     """
 
     @authenticated  # ensure only authorized users can request the server
+    def get(self, token: str):
+        """Checks if a SharedMemory object with the given token exists."""
+        try:
+            memory = SharedMemory(token)
+        except FileNotFoundError:
+            self.set_status(HTTPStatus.NOT_FOUND)
+            return self.finish({"error": f"Invalid token: {token}"})
+        memory.close()
+        self.set_status(HTTPStatus.NO_CONTENT)
+        return self.finish()
+
+    @authenticated  # ensure only authorized users can request the server
     def post(self, token: str):
+        """Writes the request body to the SharedMemory object identified by the token."""
         body = self.request.body
         if not body:
             self.set_status(HTTPStatus.BAD_REQUEST)

--- a/boa/integrations/jupyter/jupyter.js
+++ b/boa/integrations/jupyter/jupyter.js
@@ -86,6 +86,7 @@
         if (!colab) {
             // Check if the cell was already executed. In Colab, eval_js() doesn't replay.
             const response = await fetch(`../titanoboa_jupyterlab/callback/${token}`);
+            // !response.ok indicates the cell has already been executed
             if (!response.ok) return;
         }
 

--- a/boa/integrations/jupyter/jupyter.js
+++ b/boa/integrations/jupyter/jupyter.js
@@ -13,10 +13,6 @@
         return provider = new ethers.BrowserProvider(ethereum);
     };
 
-    /** Keep track of executed cells to avoid re-executing them on page reload */
-    const executed = JSON.parse(localStorage.getItem('boa.executed') || '[]');
-    window.onbeforeunload = () => localStorage.setItem('boa.executed', JSON.stringify(executed.slice(executed.length - 100)));
-
     /** Stringify data, converting big ints to strings */
     const stringify = (data) => JSON.stringify(data, (_, v) => (typeof v === 'bigint' ? v.toString() : v));
 


### PR DESCRIPTION
Jupyter replays all the `display` calls when the page is reloaded. Therefore, the JavaScript wallet triggers may run again when the page is loaded or shared with other people.

### What I did
- Introduced a check to omit running JS code when the page reloads

### How I did it
- Added a new endpoint to check whether the memory object is still valid

### How to verify it
- Save a notebook including the cell outputs. For example, the output of a contract deployment.
- Reload the page: No JS calls should be made. For example, the wallet should not ask to sign the transaction again

### Description for the changelog
- Fixed cell replays in JupyterLab

### Cute Animal Picture
![image](https://github.com/vyperlang/titanoboa/assets/2369243/10624d93-9d3e-40e0-be70-8adbdc5c9d7c)
