### PR TITLE
ci: Use `pull_request_target` with permissions check

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,9 +2,7 @@ name: unitary
 
 on:
   pull_request:
-    types: [ opened, synchronize, reopened ]
   pull_request_target:
-    types: [ opened, synchronize, reopened ]
   push:
     branches:
       - master

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -63,7 +63,6 @@ jobs:
     name: "integration tests (fork mode and Sepolia)"
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event_name == 'pull_request_target'
-    # only run in single process, so there is no contention for sepolia tx nonce
     steps:
       - name: Check if the user is a contributor
         uses: actions/github-script@v7

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,24 +1,21 @@
 name: unitary
 
-on: ["push", "pull_request"]
-
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+on: pull_request_target
 
 jobs:
   unitary:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: [ "3.10", "3.11" ]
 
     name: "unit tests: python ${{ matrix.python-version }}"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -31,15 +28,14 @@ jobs:
       - name: Run Unit Tests
         run: pytest -n auto tests/unitary/
 
-  integration:
-    name: "integration tests (forked and networked modes)"
+  anvil:
+    name: "integration tests (networked against anvil)"
     runs-on: ubuntu-latest
-    # only run in single process, so there is no contention for sepolia tx nonce
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
           cache: "pip"
@@ -52,15 +48,43 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
+      - name: Run Networked Tests against anvil
+        # run separately to clarify its dependency on outside binary
+        run: pytest -n auto tests/integration/network/anvil/
+
+  integration:
+    name: "integration tests (fork mode and Sepolia)"
+    runs-on: ubuntu-latest
+    # only run in single process, so there is no contention for sepolia tx nonce
+    steps:
+      - name: Check if the user is a contributor
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { actor: username, repo: { owner, repo } } = context;
+            const collaborator = await github.rest.repos.getCollaboratorPermissionLevel({ owner, repo, username });
+            if (!collaborator.data.user.permissions.push) {
+              core.setFailed(username + ' is not a contributor');
+            }
+
+      - uses: actions/checkout@v4
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install Requirements
+        run: |
+          pip install -r dev-requirements.txt
+          pip install .
+
       - name: Run Fork Mode Tests
         run: pytest -n auto tests/integration/fork/
         env:
           MAINNET_ENDPOINT: ${{ secrets.ALCHEMY_MAINNET_ENDPOINT }}
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
-
-      - name: Run Networked Tests against anvil
-        # run separately to clarify its dependency on outside binary
-        run: pytest -n auto tests/integration/network/anvil/
 
       - name: Run Sepolia Tests
         # disable xdist, otherwise they can contend for tx nonce

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -88,6 +88,8 @@ jobs:
             }
 
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Setup Python 3.11
         uses: actions/setup-python@v4

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,7 +47,7 @@ jobs:
           tests/unitary/
 
   anvil:
-    name: "integration tests (networked against anvil)"
+    name: "integration tests (anvil)"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
         run: pytest -n auto tests/integration/network/anvil/
 
   integration:
-    name: "integration tests (fork mode and Sepolia)"
+    name: "integration tests (Alchemy: fork mode and Sepolia)"
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event_name == 'pull_request_target'
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,6 +1,13 @@
 name: unitary
 
-on: pull_request_target
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+  pull_request_target:
+    types: [ opened, synchronize, reopened ]
+  push:
+    branches:
+      - master
 
 jobs:
   unitary:
@@ -55,6 +62,7 @@ jobs:
   integration:
     name: "integration tests (fork mode and Sepolia)"
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event_name == 'pull_request_target'
     # only run in single process, so there is no contention for sepolia tx nonce
     steps:
       - name: Check if the user is a contributor

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,7 +1,6 @@
 name: unitary
 
 on:
-  pull_request:
   pull_request_target:
   push:
     branches:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -72,7 +72,6 @@ jobs:
   integration:
     name: "integration tests (Alchemy: fork mode and Sepolia)"
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'pull_request_target'
     steps:
       - name: Check if the user is a contributor
         uses: actions/github-script@v7


### PR DESCRIPTION
### What I did
Changed the pipeline to use the `pull_request_target`, so users with push access may run the pipeline using secrets.

### How I did it
By using a small github script that calls [getCollaboratorPermissionLevel](https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#get-repository-permissions-for-a-user)

### How to verify it
Make a PR targetting this branch (pipeline) in my fork. The integration pipeline should raise an error.
[Here is an example](https://github.com/DanielSchiavini/titanoboa/actions/runs/7845528585/job/21410159640) of a successful check targeting this branch.

### Description for the changelog
N/A

### Cute Animal Picture
![image](https://github.com/vyperlang/titanoboa/assets/2369243/cbb7c3cf-c000-45cf-a647-8db3551d67c0)
