### PR TITLE
implement "native" imports for boa

### DIFF
--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -1,3 +1,4 @@
+import importlib
 import json
 import sys
 import textwrap
@@ -25,7 +26,7 @@ _Contract = Union[VyperContract, VyperBlueprint]
 _disk_cache = None
 
 
-class BoaImporter:
+class BoaImporter(importlib.abc.MetaPathFinder):
     def find_module(self, module_name, package_path):
         # Return a loader
         return self
@@ -40,20 +41,20 @@ class BoaImporter:
             to_try = Path(prefix) / path
             try:
                 ret = load_partial(to_try)
-                # comply with PEP-302:
-                ret.__name__ = to_try.name
-                ret.__file__ = str(to_try)
                 break
             except (FileNotFoundError, NotADirectoryError):
                 pass
         else:
             raise ImportError(fullname)
 
+        # comply with PEP-302:
+        ret.__name__ = to_try.name
+        ret.__file__ = str(to_try)
         sys.modules[fullname] = ret
         return ret
 
 
-sys.meta_path.append(BoaImporter())  # type: ignore
+sys.meta_path.append(BoaImporter())
 
 
 def set_cache_dir(cache_dir="~/.cache/titanoboa"):

--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -40,6 +40,7 @@ class BoaImporter:
             to_try = Path(prefix) / path
             try:
                 ret = load_partial(to_try)
+                # comply with PEP-302:
                 ret.__name__ = to_try.name
                 ret.__file__ = str(to_try)
                 break

--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -27,7 +27,7 @@ _disk_cache = None
 
 
 class BoaImporter(importlib.abc.MetaPathFinder):
-    def find_module(self, module_name, package_path):
+    def find_module(self, fullname, package_path, target=None):
         # Return a loader
         return self
 

--- a/tests/unitary/test_import_overloading.py
+++ b/tests/unitary/test_import_overloading.py
@@ -39,6 +39,9 @@ def __init__(initial_supply: uint256):
     with filepath.open("w") as f:
         f.write(code)
 
+    # note that `with mock_sys_path(tmp_path)` does not work here!
+    # apparently, there are different semantics for module loading
+    # depending on if we are in the current directory or not.
     with workdir(tmp_path):
         from foo import bar
 

--- a/tests/unitary/test_import_overloading.py
+++ b/tests/unitary/test_import_overloading.py
@@ -1,0 +1,51 @@
+import pytest
+import sys
+import contextlib
+import os
+
+from boa.interpret import VyperDeployer
+
+@contextlib.contextmanager
+def mock_sys_path(path):
+    anchor = sys.path
+    try:
+        sys.path = [path]
+        yield
+    finally:
+        sys.path = anchor
+
+@contextlib.contextmanager
+def workdir(path):
+    tmp = os.getcwd()
+    try:
+        os.chdir(path)
+        with mock_sys_path("."):
+            yield
+    finally:
+        os.chdir(tmp)
+
+def test_imports(tmp_path):
+    code = """
+totalSupply: public(uint256)
+
+@external
+def __init__(initial_supply: uint256):
+    self.totalSupply = initial_supply
+    """
+
+    filepath = tmp_path / "foo" / "bar.vy"
+    filepath.parent.mkdir(parents=True)
+
+    with filepath.open("w") as f:
+        f.write(code)
+
+    with workdir(tmp_path):
+        from foo import bar
+
+        assert isinstance(bar, VyperDeployer)
+        contract = bar.deploy(100)
+        assert contract.totalSupply() == 100
+
+        from foo import bar as baz
+        assert isinstance(baz, VyperDeployer)
+        assert baz is bar

--- a/tests/unitary/test_import_overloading.py
+++ b/tests/unitary/test_import_overloading.py
@@ -1,9 +1,9 @@
-import pytest
-import sys
 import contextlib
 import os
+import sys
 
 from boa.interpret import VyperDeployer
+
 
 @contextlib.contextmanager
 def mock_sys_path(path):
@@ -14,6 +14,7 @@ def mock_sys_path(path):
     finally:
         sys.path = anchor
 
+
 @contextlib.contextmanager
 def workdir(path):
     tmp = os.getcwd()
@@ -23,6 +24,7 @@ def workdir(path):
             yield
     finally:
         os.chdir(tmp)
+
 
 def test_imports(tmp_path):
     code = """
@@ -50,5 +52,6 @@ def __init__(initial_supply: uint256):
         assert contract.totalSupply() == 100
 
         from foo import bar as baz
+
         assert isinstance(baz, VyperDeployer)
         assert baz is bar


### PR DESCRIPTION
override `import` statement so that it looks for `.vy` files and tries to load them as `VyperDeployer`s.

### What I did

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
