### PR TITLE
feat: chain_id as integer

### DIFF
--- a/boa/integrations/jupyter/browser.py
+++ b/boa/integrations/jupyter/browser.py
@@ -134,16 +134,17 @@ class BrowserEnv(NetworkEnv):
         self.signer = BrowserSigner(address)
         self.set_eoa(self.signer)
 
-    def get_chain_id(self):
-        return _javascript_call(
+    def get_chain_id(self) -> int:
+        chain_id = _javascript_call(
             "rpc", "eth_chainId", timeout_message=RPC_TIMEOUT_MESSAGE
         )
+        return int.from_bytes(bytes.fromhex(chain_id[2:]), "big")
 
-    def set_chain_id(self, chain_id):
+    def set_chain_id(self, chain_id: int | str):
         _javascript_call(
             "rpc",
             "wallet_switchEthereumChain",
-            [{"chainId": chain_id}],
+            [{"chainId": chain_id if isinstance(chain_id, str) else hex(chain_id)}],
             timeout_message=RPC_TIMEOUT_MESSAGE,
         )
         self._reset_fork()


### PR DESCRIPTION
### What I did
Allowed chain_id to be passed as integer as that's what users are expecting.

### How I did it
- Encoding/decoding the hex string

### How to verify it
- `boa.env.set_chain_id(1)` should actually work

### Description for the changelog
- Allow integers to be passed to boa.env.set_chain_id`

### Cute Animal Picture
![image](https://github.com/vyperlang/titanoboa/assets/2369243/3d497d39-9e84-4e4d-acbc-86362a400ed4)
