### PR TITLE
Fix: storage read and refund strategy

### DIFF
--- a/boa/environment.py
+++ b/boa/environment.py
@@ -17,6 +17,7 @@ from eth.db.account import AccountDB
 from eth.db.atomic import AtomicDB
 from eth.exceptions import Halt
 from eth.vm.code_stream import CodeStream
+from eth.vm.gas_meter import allow_negative_refund_strategy
 from eth.vm.message import Message
 from eth.vm.opcode_values import STOP
 from eth.vm.transaction_context import BaseTransactionContext
@@ -28,7 +29,7 @@ from boa.util.abi import Address, abi_decode
 from boa.util.eip1167 import extract_eip1167_address, is_eip1167_contract
 from boa.vm.fast_accountdb import patch_pyevm_state_object, unpatch_pyevm_state_object
 from boa.vm.fork import AccountDBFork
-from boa.vm.gas_meters import GasMeter, NoGasMeter, ProfilingGasMeter, allow_negative_refund_strategy
+from boa.vm.gas_meters import GasMeter, NoGasMeter, ProfilingGasMeter
 from boa.vm.utils import to_bytes, to_int
 
 
@@ -271,7 +272,9 @@ class titanoboa_computation:
         self.opcodes = self.opcodes.copy()
         self.opcodes.update(_opcode_overrides)
 
-        self._gas_meter = self._gas_meter_class(self.msg.gas, refund_strategy=allow_negative_refund_strategy)
+        self._gas_meter = self._gas_meter_class(
+            self.msg.gas, refund_strategy=allow_negative_refund_strategy
+        )
         if hasattr(self._gas_meter, "_set_code"):
             self._gas_meter._set_code(self.code)
 

--- a/boa/environment.py
+++ b/boa/environment.py
@@ -28,7 +28,7 @@ from boa.util.abi import Address, abi_decode
 from boa.util.eip1167 import extract_eip1167_address, is_eip1167_contract
 from boa.vm.fast_accountdb import patch_pyevm_state_object, unpatch_pyevm_state_object
 from boa.vm.fork import AccountDBFork
-from boa.vm.gas_meters import GasMeter, NoGasMeter, ProfilingGasMeter
+from boa.vm.gas_meters import GasMeter, NoGasMeter, ProfilingGasMeter, allow_negative_refund_strategy
 from boa.vm.utils import to_bytes, to_int
 
 
@@ -271,7 +271,7 @@ class titanoboa_computation:
         self.opcodes = self.opcodes.copy()
         self.opcodes.update(_opcode_overrides)
 
-        self._gas_meter = self._gas_meter_class(self.msg.gas)
+        self._gas_meter = self._gas_meter_class(self.msg.gas, refund_strategy=allow_negative_refund_strategy)
         if hasattr(self._gas_meter, "_set_code"):
             self._gas_meter._set_code(self.code)
 

--- a/boa/vm/fork.py
+++ b/boa/vm/fork.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from typing import Any, Type
 
 from requests import HTTPError
@@ -12,6 +13,7 @@ import rlp
 from eth.db.account import AccountDB, keccak
 from eth.db.backends.memory import MemoryDB
 from eth.db.cache import CacheDB
+from eth.db.journal import JournalDB
 from eth.rlp.accounts import Account
 from eth.vm.interrupt import MissingBytecode
 from eth.vm.message import Message
@@ -28,6 +30,7 @@ _PREDEFINED_BLOCKS = {"safe", "latest", "finalized", "pending", "earliest"}
 
 
 _EMPTY = b""  # empty rlp stuff
+_HAS_KEY = b"\x01"  # could be anything
 
 
 class CachingRPC(RPC):
@@ -38,6 +41,8 @@ class CachingRPC(RPC):
         if cache_file is not None:
             try:
                 from boa.util.leveldb import LevelDB
+
+                print("(using leveldb)", file=sys.stderr)
 
                 cache_file = os.path.expanduser(cache_file)
                 # use CacheDB as an additional layer over disk
@@ -133,6 +138,8 @@ class AccountDBFork(AccountDB):
 
     def __init__(self, rpc: CachingRPC, block_identifier: str, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+
+        self._dontfetch = JournalDB(MemoryDB())
 
         self._rpc = rpc
 
@@ -255,26 +262,47 @@ class AccountDBFork(AccountDB):
             )
             return to_bytes(ret)
 
+    def discard(self, checkpoint):
+        super().discard(checkpoint)
+        self._dontfetch.discard(checkpoint)
+
+    def commit(self, checkpoint):
+        super().commit(checkpoint)
+        self._dontfetch.commit(checkpoint)
+
+    def record(self):
+        checkpoint = super().record()
+        self._dontfetch.record(checkpoint)
+        return checkpoint
+
+    # helper to determine if something is in the storage db
+    # or we need to get from RPC
+    def _helper_have_storage(self, address, slot, from_journal=True):
+        if not from_journal:
+            db = super()._get_address_store(address)._locked_changes
+            key = int_to_big_endian(slot)
+            return db.get(key, _EMPTY) != _EMPTY
+
+        key = self._get_storage_tracker_key(address, slot)
+        return self._dontfetch.get(key) == _HAS_KEY
+
     def get_storage(self, address, slot, from_journal=True):
         # call super for address warming semantics
         val = super().get_storage(address, slot, from_journal)
-
-        # check if we have the storage locally in the VM already
-        # cf. AccountStorageDB.get()
-        store = super()._get_address_store(address)
-        key = int_to_big_endian(slot)
-        if store._locked_changes.get(key, _EMPTY) != _EMPTY:
-            return val
-        if from_journal and store._journal_storage.get(key, _EMPTY) != _EMPTY:
+        if self._helper_have_storage(address, slot, from_journal=from_journal):
             return val
 
         addr = to_checksum_address(address)
-        res = self._rpc.fetch("eth_getStorageAt", [addr, to_hex(slot), self._block_id])
-        ret = to_int(res)
-        # Save value to local storage
-        store._locked_changes[key] = rlp.encode(ret)
+        raw_val = self._rpc.fetch(
+            "eth_getStorageAt", [addr, to_hex(slot), self._block_id]
+        )
+        return to_int(raw_val)
 
-        return ret
+    def set_storage(self, address, slot, value):
+        super().set_storage(address, slot, value)
+        # mark don't fetch
+        key = self._get_storage_tracker_key(address, slot)
+        self._dontfetch[key] = _HAS_KEY
 
     def account_exists(self, address):
         if super().account_exists(address):

--- a/boa/vm/fork.py
+++ b/boa/vm/fork.py
@@ -262,10 +262,10 @@ class AccountDBFork(AccountDB):
         # check if we have the storage locally in the VM already
         # cf. AccountStorageDB.get()
         store = super()._get_address_store(address)
-        db = store._journal_storage if from_journal else store._locked_changes
         key = int_to_big_endian(slot)
-        if db.get(key, _EMPTY) != _EMPTY:
-            # we have it locally - skip rpc fetch
+        if store._locked_changes.get(key, _EMPTY) != _EMPTY:
+            return val
+        if from_journal and store._journal_storage.get(key, _EMPTY) != _EMPTY:
             return val
 
         addr = to_checksum_address(address)

--- a/boa/vm/fork.py
+++ b/boa/vm/fork.py
@@ -263,12 +263,15 @@ class AccountDBFork(AccountDB):
         key = int_to_big_endian(slot)
 
         # Read from local storage if there are any records
-        if store._locked_changes._journal.get(key) is not None or \
-                (from_journal and store._journal_storage._journal.get(key) is not None):
+        if store._locked_changes._journal.get(key) is not None or (
+            from_journal and store._journal_storage._journal.get(key) is not None
+        ):
             return super().get_storage(address, slot, from_journal)
 
         addr = to_checksum_address(address)
-        value = to_int(self._rpc.fetch("eth_getStorageAt", [addr, to_hex(slot), self._block_id]))
+        value = to_int(
+            self._rpc.fetch("eth_getStorageAt", [addr, to_hex(slot), self._block_id])
+        )
         store._locked_changes[key] = rlp.encode(value)  # Save value to local storage
         return value
 

--- a/boa/vm/gas_meters.py
+++ b/boa/vm/gas_meters.py
@@ -9,7 +9,7 @@ class NoGasMeter:
     performance boost.
     """
 
-    def __init__(self, start_gas):
+    def __init__(self, start_gas, *args, **kwargs):
         pass
 
     def consume_gas(self, amount, reason):

--- a/boa/vm/gas_meters.py
+++ b/boa/vm/gas_meters.py
@@ -1,4 +1,4 @@
-from eth.vm.gas_meter import GasMeter
+from eth.vm.gas_meter import GasMeter, allow_negative_refund_strategy
 
 
 class NoGasMeter:

--- a/boa/vm/gas_meters.py
+++ b/boa/vm/gas_meters.py
@@ -1,4 +1,4 @@
-from eth.vm.gas_meter import GasMeter, allow_negative_refund_strategy
+from eth.vm.gas_meter import GasMeter
 
 
 class NoGasMeter:

--- a/tests/integration/fork/test_abi_contract.py
+++ b/tests/integration/fork/test_abi_contract.py
@@ -148,7 +148,6 @@ def flip_from(_input: uint256) -> uint256:
     with boa.env.prank(pool):
         crvusd.approve(e, 2 ** 256 - 1)
         e.flip_from(initial_balance)
-    print(initial, crvusd.balanceOf(pool), crvusd.balanceOf(e))
     assert crvusd.balanceOf(pool) == initial_balance // 2
     assert crvusd.balanceOf(e) == initial_balance - initial_balance // 2
 

--- a/tests/integration/fork/test_abi_contract.py
+++ b/tests/integration/fork/test_abi_contract.py
@@ -130,7 +130,8 @@ def test_fork_write(crvusd, n):
 
 
 def test_fork_write_flip(crvusd):
-    e = boa.loads(f"""
+    e = boa.loads(
+        f"""
 from vyper.interfaces import ERC20
 crvUSD: ERC20
 @external
@@ -141,12 +142,12 @@ def flip_from(_input: uint256) -> uint256:
     self.crvUSD.transferFrom(msg.sender, self, _input)
     self.crvUSD.transfer(msg.sender, _input / 2)
     return _input / 2
-""")
+"""
+    )
     pool = "0x4dece678ceceb27446b35c672dc7d61f30bad69e"
     initial_balance = crvusd.balanceOf(pool)
-    initial = (initial_balance, crvusd.balanceOf(e))
     with boa.env.prank(pool):
-        crvusd.approve(e, 2 ** 256 - 1)
+        crvusd.approve(e, 2**256 - 1)
         e.flip_from(initial_balance)
     assert crvusd.balanceOf(pool) == initial_balance // 2
     assert crvusd.balanceOf(e) == initial_balance - initial_balance // 2

--- a/tests/integration/fork/test_abi_contract.py
+++ b/tests/integration/fork/test_abi_contract.py
@@ -129,6 +129,7 @@ def test_fork_write(crvusd, n):
     assert crvusd.balanceOf(account_b) == balances[account_b] + n
 
 
+# test net gas metering negative refund
 def test_fork_write_flip(crvusd):
     e = boa.loads(
         f"""
@@ -142,7 +143,7 @@ def flip_from(_input: uint256) -> uint256:
     self.crvUSD.transferFrom(msg.sender, self, _input)
     self.crvUSD.transfer(msg.sender, _input / 2)
     return _input / 2
-"""
+    """
     )
     pool = "0x4dece678ceceb27446b35c672dc7d61f30bad69e"
     initial_balance = crvusd.balanceOf(pool)


### PR DESCRIPTION
### What I did
- Storage does not show deleted slots as though they are not registered. Thence data is fetched from RPC and leads to errors.
- According to [EIP2200 specification](https://eips.ethereum.org/EIPS/eip-2200) call-frame refund counters can go negative, so I changed strategy to appropriate.

### How I did it
- Added more precise checks along with autocaching values.
- Set strategy at initialisation.

### How to verify it
There is a test flipping slot to zero and back.

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.ibb.co/QbJNLf8/can-anyone-explain-the-song-stone-in-focus-aphex-twin-v0-r1qt8wlkyc4c1-png-ezgif-com-webp-to-jpg-con.jpg)
