### PR TITLE
Split pipelines to run only integration tests with pull_request_trigger

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,0 +1,61 @@
+name: integration
+
+on:
+  pull_request_target:
+  push:
+    branches:
+      - master
+
+jobs:
+  integration:
+    name: "integration tests (Alchemy: fork mode and Sepolia)"
+    runs-on: ubuntu-latest
+    steps:
+
+      # given we use the pull_request_trigger, only allow contributors to run tests with secrets
+      - name: Check if the user is a contributor
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { actor: username, repo: { owner, repo } } = context;
+            const collaborator = await github.rest.repos.getCollaboratorPermissionLevel({ owner, repo, username });
+            if (!collaborator.data.user.permissions.push) {
+              core.setFailed(username + ' is not a contributor');
+            }
+
+      # specifically check out the head ref, not the default base ref. Depth is needed for the merge step.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 2
+
+      # we want to run the tests on a merge commit, so we need to merge the base branch into the head branch
+      - name: Merge base branch
+        if: github.event_name == 'pull_request_target'
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          git merge origin/${{ github.base_ref }} --no-edit
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install Requirements
+        run: |
+          pip install -r dev-requirements.txt
+          pip install .
+
+      - name: Run Fork Mode Tests
+        run: pytest -n auto tests/integration/fork/
+        env:
+          MAINNET_ENDPOINT: ${{ secrets.ALCHEMY_MAINNET_ENDPOINT }}
+          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+
+      - name: Run Sepolia Tests
+        # disable xdist, otherwise they can contend for tx nonce
+        run: pytest -n 0 tests/integration/network/sepolia/
+        env:
+          SEPOLIA_ENDPOINT: ${{ secrets.ALCHEMY_SEPOLIA_ENDPOINT }}
+          SEPOLIA_PKEY: ${{ secrets.SEPOLIA_PKEY }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,7 +1,7 @@
 name: unitary
 
 on:
-  pull_request_target:
+  pull_request:
   push:
     branches:
       - master
@@ -68,45 +68,3 @@ jobs:
       - name: Run Networked Tests against anvil
         # run separately to clarify its dependency on outside binary
         run: pytest -n auto tests/integration/network/anvil/
-
-  integration:
-    name: "integration tests (Alchemy: fork mode and Sepolia)"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check if the user is a contributor
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { actor: username, repo: { owner, repo } } = context;
-            const collaborator = await github.rest.repos.getCollaboratorPermissionLevel({ owner, repo, username });
-            if (!collaborator.data.user.permissions.push) {
-              core.setFailed(username + ' is not a contributor');
-            }
-
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
-
-      - name: Setup Python 3.11
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-          cache: "pip"
-
-      - name: Install Requirements
-        run: |
-          pip install -r dev-requirements.txt
-          pip install .
-
-      - name: Run Fork Mode Tests
-        run: pytest -n auto tests/integration/fork/
-        env:
-          MAINNET_ENDPOINT: ${{ secrets.ALCHEMY_MAINNET_ENDPOINT }}
-          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
-
-      - name: Run Sepolia Tests
-        # disable xdist, otherwise they can contend for tx nonce
-        run: pytest -n 0 tests/integration/network/sepolia/
-        env:
-          SEPOLIA_ENDPOINT: ${{ secrets.ALCHEMY_SEPOLIA_ENDPOINT }}
-          SEPOLIA_PKEY: ${{ secrets.SEPOLIA_PKEY }}


### PR DESCRIPTION
### What I did
Moved the integration tests to a separate pipeline
Merge the base branch into the PR for integration tests
Move the other tests back to the pull_request trigger

### How I did it
- merge_commit_sha is not available
- We need to manually merge the base branch.

### How to verify it
After merging this PR, new PRs with pull_request_target should work on the merge commit.
See the pipeline run at https://github.com/DanielSchiavini/titanoboa/pull/4

### Description for the changelog
N/A

### Cute Animal Picture

![image](https://github.com/vyperlang/titanoboa/assets/2369243/c98b8626-0ac8-4a5c-adcd-f4ea346db282)
