### PR TITLE
fix: import error messages

### DIFF
--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -27,29 +27,38 @@ _disk_cache = None
 
 
 class BoaImporter(importlib.abc.MetaPathFinder):
+    def __init__(self):
+        self._path_lookup = {}
+
     def find_module(self, fullname, package_path, target=None):
-        # Return a loader
-        return self
+        # note: maybe instead of looping, append path to package_path
+        path = Path(fullname.replace(".", "/")).with_suffix(".vy")
+
+        for prefix in package_path:
+            # for fullname == "x.y.z"
+            # prefix looks something like "<...>/site-packages/x"
+            to_try = Path(prefix).parent / path
+
+            if to_try.exists():
+                self._path_lookup[fullname] = to_try
+                return self
+
+        return None
 
     def load_module(self, fullname):
-        # Return a module
         if fullname in sys.modules:
             return sys.modules[fullname]
 
-        path = Path(fullname.replace(".", "/")).with_suffix(".vy")
-        for prefix in sys.path:
-            to_try = Path(prefix) / path
-            try:
-                ret = load_partial(to_try)
-                break
-            except (FileNotFoundError, NotADirectoryError):
-                pass
-        else:
-            raise ImportError(fullname)
+        # import system should guarantee this, but be paranoid
+        if fullname not in self._path_lookup:
+            raise ImportError(f"invariant violated: no lookup for {fullname}")
+
+        path = self._path_lookup[fullname]
+        ret = load_partial(path)
 
         # comply with PEP-302:
-        ret.__name__ = to_try.name
-        ret.__file__ = str(to_try)
+        ret.__name__ = path.name
+        ret.__file__ = str(path)
         sys.modules[fullname] = ret
         return ret
 


### PR DESCRIPTION
fix import error messages by fixing compliance with the metapath protocol. instead of always returning a module loader which errors out if it can't find a module, return None early (from find_module) if we can't find the module. this lets the system fall back to the system error handling for not-found modules.

### What I did

### How I did it
try importing a non-existent module with and without this patch. the results should look like:
(unpatched):
```python
>>> import boa
>>> import asdlkfj
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/charles/titanoboa/boa/interpret.py", line 48, in load_module
    raise ImportError(fullname)
ImportError: asdlkfj
>>> from requests import asldkjfasdf
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/charles/titanoboa/boa/interpret.py", line 48, in load_module
    raise ImportError(fullname)
ImportError: requests.asldkjfasdf
```
(patched):
```python
>>> import boa
>>> import asdlkfj
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'asdlkfj'
>>> from requests import asldkjfasdf
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'asldkjfasdf' from 'requests' (/home/charles/.venvs/boa/lib/python3.11/site-packages/requests/__init__.py)
```

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
