### PR TITLE
fix RecursionError tracing child computations

### DIFF
--- a/boa/environment.py
+++ b/boa/environment.py
@@ -723,7 +723,7 @@ class Env:
             if child.msg.code_address == b"":
                 continue
             child_contract = self._lookup_contract_fast(child.msg.code_address)
-            self._hook_trace_computation(computation, child_contract)
+            self._hook_trace_computation(child, child_contract)
 
     # function to time travel
     def time_travel(

--- a/tests/unitary/test_coverage.py
+++ b/tests/unitary/test_coverage.py
@@ -1,0 +1,40 @@
+import pytest
+import boa
+
+
+@pytest.fixture(scope="module")
+def external_contract():
+    source_code = """
+@external
+@view
+def foo(a: uint256) -> uint256:
+    return a * a
+"""
+    return boa.loads(source_code, name="ExternalContract")
+
+
+@pytest.fixture(scope="module")
+def source_contract(external_contract):
+    source_code = """
+interface Foo:
+    def foo(a: uint256) -> uint256: view
+
+FOO: immutable(address)
+
+@external
+def __init__(_foo_address: address):
+    FOO = _foo_address
+
+@external
+@view
+def bar(b: uint256) -> uint256:
+    c: uint256 = Foo(FOO).foo(b)
+    return c
+"""
+    return boa.loads(source_code, external_contract.address, name="TestContract")
+
+
+def test_sub_computations(source_contract):
+    boa.env._coverage_enabled = True
+    source_contract.bar(10)
+


### PR DESCRIPTION
### What I did

Fix a `RecursionError: maximum recursion depth exceeded in comparison` happening while running tests with code coverage enabled.

```
.venv/lib/python3.11/site-packages/boa/contracts/vyper/vyper_contract.py:1007: in __call__
    computation = self.env.execute_code(
.venv/lib/python3.11/site-packages/boa/environment.py:709: in execute_code
    self._hook_trace_computation(ret, contract)
.venv/lib/python3.11/site-packages/boa/environment.py:726: in _hook_trace_computation
    self._hook_trace_computation(computation, child_contract)
.venv/lib/python3.11/site-packages/boa/environment.py:726: in _hook_trace_computation
    self._hook_trace_computation(computation, child_contract)
.venv/lib/python3.11/site-packages/boa/environment.py:726: in _hook_trace_computation
    self._hook_trace_computation(computation, child_contract)
E   RecursionError: maximum recursion depth exceeded in comparison
!!! Recursion detected (same locals & position)
```

### How I did it

* Fix computation's children iteration in `_hook_trace_computation`
* Add unit test to check the fix
 
### How to verify it

The test (`tests/unitary/test_coverage.py`) should pass with the fix and fail without it

### Description for the changelog

### Cute Animal Picture


![core_image_v2_lora_cute_animals](https://github.com/vyperlang/titanoboa/assets/9967526/6ca05f6f-da49-4f1a-9043-55485f4f4b0f)
