### PR TITLE
Keep abi in ABIContract

### DIFF
--- a/boa/contracts/abi/abi_contract.py
+++ b/boa/contracts/abi/abi_contract.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from copy import deepcopy
 from functools import cached_property
 from os.path import basename
 from typing import Any, Optional, Union
@@ -243,6 +244,10 @@ class ABIContract(_BaseEVMContract):
         self._address = Address(address)
 
     @cached_property
+    def abi(self):
+        return deepcopy(self._abi)
+
+    @cached_property
     def method_id_map(self):
         """
         Returns a mapping from method id to function object.
@@ -305,6 +310,10 @@ class ABIContractFactory:
         self._name = name
         self._abi = abi
         self._filename = filename
+
+    @cached_property
+    def abi(self):
+        return deepcopy(self._abi)
 
     @classmethod
     def from_abi_dict(cls, abi, name="<anonymous contract>"):

--- a/boa/contracts/vyper/vyper_contract.py
+++ b/boa/contracts/vyper/vyper_contract.py
@@ -24,6 +24,7 @@ from vyper.codegen.ir_node import IRnode
 from vyper.codegen.module import generate_ir_for_module
 from vyper.compiler import CompilerData
 from vyper.compiler import output as compiler_output
+from vyper.compiler.output import build_abi_output
 from vyper.compiler.settings import OptimizationLevel
 from vyper.evm.opcodes import anchor_evm_version
 from vyper.exceptions import VyperException
@@ -142,6 +143,10 @@ class _BaseVyperContract(_BaseEVMContract):
 
         with anchor_compiler_settings(self.compiler_data):
             _ = compiler_data.bytecode, compiler_data.bytecode_runtime
+
+    @cached_property
+    def abi(self):
+        return build_abi_output(self.compiler_data)
 
 
 # create a blueprint for use with `create_from_blueprint`.

--- a/tests/integration/fork/test_from_etherscan.py
+++ b/tests/integration/fork/test_from_etherscan.py
@@ -33,6 +33,7 @@ def test_crvusd_contract(crvusd_contract):
 
 
 def test_proxy_contract(proxy_contract):
+    assert proxy_contract._abi is not None
     assert proxy_contract.minTime() == 43200
     assert proxy_contract.voteTime() == 604800
     assert proxy_contract.minBalance() == 2500000000000000000000

--- a/tests/integration/fork/test_from_etherscan.py
+++ b/tests/integration/fork/test_from_etherscan.py
@@ -33,7 +33,7 @@ def test_crvusd_contract(crvusd_contract):
 
 
 def test_proxy_contract(proxy_contract):
-    assert proxy_contract._abi is not None
+    assert isinstance(proxy_contract._abi, dict)
     assert proxy_contract.minTime() == 43200
     assert proxy_contract.voteTime() == 604800
     assert proxy_contract.minBalance() == 2500000000000000000000

--- a/tests/unitary/test_abi.py
+++ b/tests/unitary/test_abi.py
@@ -2,7 +2,6 @@ import re
 
 import pytest
 import yaml
-from vyper.compiler.output import build_abi_output
 
 import boa
 from boa import BoaError
@@ -11,10 +10,9 @@ from boa.util.abi import Address
 
 
 def load_via_abi(code):
-    vyper_contract = boa.loads(code)
-    abi = build_abi_output(vyper_contract.compiler_data)
-    abi_contract = ABIContractFactory.from_abi_dict(abi).at(vyper_contract.address)
-    return abi_contract, vyper_contract
+    contract = boa.loads(code)
+    factory = ABIContractFactory.from_abi_dict(contract.abi)
+    return factory.at(contract.address), contract
 
 
 @pytest.fixture()


### PR DESCRIPTION
### What I did
- Added _abi field to ABIContract, so it can be available for later use, e.g. when using `fetch_from_etherscan`

### How I did it
- Moving the function creation to the ABIContract

### How to verify it
- The ABI is still available after the contract is created

### Description for the changelog
N/A

### Cute Animal Picture
![image](https://github.com/vyperlang/titanoboa/assets/2369243/4e0c9970-5a35-4f5a-b23f-6b098c500579)
