### PR TITLE
fix: lab view URL

### DIFF
--- a/boa/integrations/jupyter/jupyter.js
+++ b/boa/integrations/jupyter/jupyter.js
@@ -11,6 +11,9 @@
         return ethereum.request({method, params});
     };
 
+    // When opening in lab view, the base path contains extra folders
+    const base = location.pathname.includes("/lab/workspaces/auto-L") ? "../../../../.." : "..";
+
     /** Stringify data, converting big ints to strings */
     const stringify = (data) => JSON.stringify(data, (_, v) => (typeof v === 'bigint' ? v.toString() : v));
 
@@ -33,7 +36,7 @@
     async function callbackAPI(token, body) {
         const headers = {['X-XSRFToken']: getCookie('_xsrf')};
         const init = {method: 'POST', body, headers};
-        const url = `../titanoboa_jupyterlab/callback/${token}`;
+        const url = `${base}/titanoboa_jupyterlab/callback/${token}`;
         const response = await fetch(url, init);
         return response.text();
     }
@@ -84,8 +87,6 @@
     /** Call the backend when the given function is called, handling errors */
     const handleCallback = func => async (token, ...args) => {
         if (!colab) {
-            // When opening in lab view, the base path contains extra folders
-            const base = location.pathname.includes("/lab/workspaces/auto-L") ? "../../../.." : "..";
             // Check if the cell was already executed. In Colab, eval_js() doesn't replay.
             const response = await fetch(`${base}/titanoboa_jupyterlab/callback/${token}`);
             // !response.ok indicates the cell has already been executed

--- a/boa/integrations/jupyter/jupyter.js
+++ b/boa/integrations/jupyter/jupyter.js
@@ -12,7 +12,7 @@
     };
 
     // When opening in lab view, the base path contains extra folders
-    const base = location.pathname.includes("/lab/workspaces/auto-L") ? "../../../../.." : "..";
+    const base = location.pathname.includes("/lab/") ? "../.." : "..";
 
     /** Stringify data, converting big ints to strings */
     const stringify = (data) => JSON.stringify(data, (_, v) => (typeof v === 'bigint' ? v.toString() : v));

--- a/boa/integrations/jupyter/jupyter.js
+++ b/boa/integrations/jupyter/jupyter.js
@@ -3,7 +3,7 @@
  * BrowserSigner to the frontend.
  */
 (() => {
-    const rpc = (method, params) => {
+    const rpc = async (method, params) => {
         const {ethereum} = window;
         if (!ethereum) {
             throw new Error('No Ethereum plugin found. Please authorize the site on your browser wallet.');
@@ -84,8 +84,10 @@
     /** Call the backend when the given function is called, handling errors */
     const handleCallback = func => async (token, ...args) => {
         if (!colab) {
+            // When opening in lab view, the base path contains extra folders
+            const base = location.pathname.includes("/lab/workspaces/auto-L") ? "../../../.." : "..";
             // Check if the cell was already executed. In Colab, eval_js() doesn't replay.
-            const response = await fetch(`../titanoboa_jupyterlab/callback/${token}`);
+            const response = await fetch(`${base}/titanoboa_jupyterlab/callback/${token}`);
             // !response.ok indicates the cell has already been executed
             if (!response.ok) return;
         }

--- a/tests/unitary/test_coverage.py
+++ b/tests/unitary/test_coverage.py
@@ -1,4 +1,5 @@
 import pytest
+
 import boa
 
 
@@ -37,4 +38,3 @@ def bar(b: uint256) -> uint256:
 def test_sub_computations(source_contract):
     boa.env._coverage_enabled = True
     source_contract.bar(10)
-


### PR DESCRIPTION
### What I did
- Fixed callback URL when opening in lab view, i.e. `https://try.vyperlang.org/user/{user}/lab/workspaces/auto-L/tree/{file}.ipynb` instead of the notebook URL `https://try.vyperlang.org/user/{user}/notebooks/{file}.ipynb`

### How I did it
- Check if we are in lab view, if so recurse 3 directories
- Added `async` to `rpc` so the exception is displayed properly

### How to verify it
- Open the notebook in the 2 views mentioned, it should work the same.

### Description for the changelog
- Fixed jupyter plugin lab view

### Cute Animal Picture
![image](https://github.com/vyperlang/titanoboa/assets/2369243/5e308bc1-5652-4b4a-8af2-11a5cd8cd104)
