### PR TITLE
chore: update requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,11 @@ dependencies = [
     "hypothesis",
     "pytest",
     "pytest-cov",
+
+    # eth-rlp requirement, not installed by default with 3.12
+    "typing-extensions",
+
+    # gas profiling tables
     "rich",
 
     # required for forking:


### PR DESCRIPTION
ran into this when upgrading to python 3.12. seems like it's a regression in eth-rlp dependency specification

### What I did

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
