### PR TITLE
fix: Notify user of tx fail in boa call output

### DIFF
--- a/boa/contracts/vyper/vyper_contract.py
+++ b/boa/contracts/vyper/vyper_contract.py
@@ -160,6 +160,7 @@ class VyperBlueprint(_BaseVyperContract):
         override_address=None,
         blueprint_preamble=b"\xFE\x71\x00",
         filename=None,
+        gas=None,
     ):
         # note slight code duplication with VyperContract ctor,
         # maybe use common base class?
@@ -177,7 +178,7 @@ class VyperBlueprint(_BaseVyperContract):
         deploy_bytecode += blueprint_bytecode
 
         addr, self.bytecode = self.env.deploy_code(
-            bytecode=deploy_bytecode, override_address=override_address
+            bytecode=deploy_bytecode, override_address=override_address, gas=gas
         )
 
         self._address = Address(addr)
@@ -472,6 +473,7 @@ class VyperContract(_BaseVyperContract):
         skip_initcode=False,
         created_from: Address = None,
         filename: str = None,
+        gas=None,
     ):
         super().__init__(compiler_data, env, filename)
 
@@ -492,7 +494,7 @@ class VyperContract(_BaseVyperContract):
         if skip_initcode:
             addr = Address(override_address)
         else:
-            addr = self._run_init(*args, override_address=override_address)
+            addr = self._run_init(*args, override_address=override_address, gas=gas)
         self._address = addr
 
         for fn_name, fn in external_fns.items():
@@ -513,14 +515,14 @@ class VyperContract(_BaseVyperContract):
 
         self.env.register_contract(self._address, self)
 
-    def _run_init(self, *args, override_address=None):
+    def _run_init(self, *args, override_address=None, gas=None):
         encoded_args = b""
         if self._ctor:
             encoded_args = self._ctor.prepare_calldata(*args)
 
         initcode = self.compiler_data.bytecode + encoded_args
         addr, self.bytecode = self.env.deploy_code(
-            bytecode=initcode, override_address=override_address
+            bytecode=initcode, override_address=override_address, gas=gas
         )
         return Address(addr)
 

--- a/boa/network.py
+++ b/boa/network.py
@@ -419,6 +419,8 @@ class NetworkEnv(Env):
         print(f"tx broadcasted: {tx_hash}")
 
         receipt = self._rpc.wait_for_tx_receipt(tx_hash, self.tx_settings.poll_timeout)
+        if receipt["status"] != "0x1":
+            raise RuntimeError(f"txn failed: {receipt}")
 
         trace = None
         if self._tracer is not None:

--- a/tests/integration/network/anvil/test_network_env.py
+++ b/tests/integration/network/anvil/test_network_env.py
@@ -56,4 +56,11 @@ def test_raise_exception(simple_contract, t):
         simple_contract.raise_exception(t)
 
 
+def test_failed_transaction():
+    with pytest.raises(RuntimeError) as ctx:
+        boa.loads(code, STARTING_SUPPLY, gas=149377)
+    error = str(ctx.value)
+    assert error.startswith("txn failed:")
+
+
 # XXX: probably want to test deployment revert behavior

--- a/tests/unitary/test_fixture_order.py
+++ b/tests/unitary/test_fixture_order.py
@@ -6,20 +6,23 @@ import pytest
 # eth_utils.exceptions.ValidationError: No checkpoint 31 was found
 
 
-@pytest.fixture(scope='module', autouse=True, params=[7,8,9])
+@pytest.fixture(scope="module", autouse=True, params=[7, 8, 9])
 def fixture_autouse(request):
     print(f"SETUP FIXTURE AUTOUSE {request.param}")
     yield
     print(f"TEARDOWN FIXTURE AUTOUSE {request.param}")
 
-@pytest.fixture(scope='module', params=[1,2,3])
+
+@pytest.fixture(scope="module", params=[1, 2, 3])
 def fixture_test(request):
     print(f"SETUP FIXTURE TEST {request.param}")
     yield
     print(f"TEARDOWN FIXTURE TEST {request.param}")
 
+
 def test_1(fixture_test):
     pass
+
 
 def test_2():
     pass


### PR DESCRIPTION
Closes #138

### What I did
- Check whether the transaction receipt has a success status

### How I did it
- Checking the return of [eth_getTransactionReceipt](https://www.quicknode.com/docs/ethereum/eth_getTransactionReceipt)

### How to verify it
- Test is included

### Description for the changelog
- Notify user if the transaction receipt returns a failed status

### Cute Animal Picture

![image](https://github.com/vyperlang/titanoboa/assets/2369243/31cba51c-6f11-4104-98e4-1b3074f8a112)
