### PR TITLE
feat(etherscan): Retry on rate limit and in-memory caching

### DIFF
--- a/boa/explorer.py
+++ b/boa/explorer.py
@@ -1,22 +1,44 @@
 import json
+import logging
+from time import sleep
 from typing import Optional
 
 import requests
 
 SESSION = requests.Session()
+_cached_abi: dict[str, dict] = {}
 
 
 def _fetch_etherscan(uri: str, api_key: Optional[str] = None, **params) -> dict:
+    """
+    Fetch data from Etherscan API.
+    Offers a simple caching mechanism to avoid redundant queries.
+    Retries if rate limit is reached.
+    :param uri: Etherscan API URI
+    :param api_key: Etherscan API key
+    :param params: Query parameters
+    :return: JSON response
+    """
+    if uri in _cached_abi:
+        return _cached_abi[uri]
+
     if api_key is not None:
         params["apikey"] = api_key
 
-    res = SESSION.get(uri, params=params)
-    res.raise_for_status()
-    data = res.json()
+    for _ in range(10):
+        res = SESSION.get(uri, params=params)
+        res.raise_for_status()
+        data = res.json()
+        if data.get("result") != "Max rate limit reached":
+            break
+        logging.warning("Rate limit reached, retrying...")
+        sleep(0.3)
 
     if int(data["status"]) != 1:
         raise ValueError(f"Failed to retrieve data from API: {data}")
 
+    logging.warning(f"Queried Etherscan API with params: {params}")
+    _cached_abi[uri] = data
     return data
 
 


### PR DESCRIPTION
### What I did
- Retry when Etherscan has rate limited the call so the user is not stuck
- Add in-memory caching for etherscan calls - this can be extended in the future


### Cute Animal Picture
![image](https://github.com/vyperlang/titanoboa/assets/2369243/b8397ac1-830f-468f-82c6-1457d875281d)
