### PR TITLE
fix: local variable 'snapshot_id' referenced before assignment

### DIFF
--- a/boa/network.py
+++ b/boa/network.py
@@ -132,16 +132,16 @@ class NetworkEnv(Env):
     def anchor(self):
         if not self._rpc_has_snapshot:
             raise RuntimeError("RPC does not have `evm_snapshot` capability!")
+        block_number = self.evm.patch.block_number
+        snapshot_id = self._rpc.fetch("evm_snapshot", [])
         try:
-            block_id = self.evm.patch.block_id
-            snapshot_id = self._rpc.fetch("evm_snapshot", [])
             yield
             # note we cannot call super.anchor() because vm/accountdb fork
             # state is reset after every txn.
         finally:
             self._rpc.fetch("evm_revert", [snapshot_id])
             # wipe forked state
-            self._reset_fork(block_id)
+            self._reset_fork(block_number)
 
     # add account, or "Account-like" object. MUST expose
     # `sign_transaction` or `send_transaction` method!

--- a/tests/unitary/test_time_travel.py
+++ b/tests/unitary/test_time_travel.py
@@ -9,16 +9,16 @@ def test_no_inputs():
 
 
 def test_block_travel():
-    old_block = boa.env.evm.block_number
-    old_timestamp = boa.env.evm.timestamp
+    old_block = boa.env.evm.patch.block_number
+    old_timestamp = boa.env.evm.patch.timestamp
     boa.env.time_travel(blocks=420)
-    assert boa.env.evm.block_number == old_block + 420
-    assert boa.env.evm.timestamp == old_timestamp + 420 * 12
+    assert boa.env.evm.patch.block_number == old_block + 420
+    assert boa.env.evm.patch.timestamp == old_timestamp + 420 * 12
 
 
 def test_seconds_travel():
-    old_timestamp = boa.env.evm.timestamp
-    old_block = boa.env.evm.block_number
+    old_timestamp = boa.env.evm.patch.timestamp
+    old_block = boa.env.evm.patch.block_number
     boa.env.time_travel(seconds=69)
-    assert boa.env.evm.timestamp == old_timestamp + 69
-    assert boa.env.evm.block_number == old_block + 69 // 12
+    assert boa.env.evm.patch.timestamp == old_timestamp + 69
+    assert boa.env.evm.patch.block_number == old_block + 69 // 12


### PR DESCRIPTION
### What I did
Fix UnboundLocalError: local variable 'snapshot_id' referenced before assignment

This was caused by a typo, the property `block_id` was removed in #134. Another typo broke the time travel tests.

### How I did it
Used the correct `block_number` property

### How to verify it
Unit tests should pass

### Description for the changelog
Fix UnboundLocalError: local variable 'snapshot_id' referenced before assignment

### Cute Animal Picture

![image](https://github.com/vyperlang/titanoboa/assets/2369243/ce008796-d8ac-4ea2-a49e-09a5f4e22868)
