### PR TITLE
Cache db

### DIFF
--- a/boa/vm/fork.py
+++ b/boa/vm/fork.py
@@ -52,7 +52,7 @@ class CachingRPC(RPC):
                     # use CacheDB as an additional layer over disk
                     # (ideally would use leveldb lru cache but it's not configurable
                     # via LevelDB API).
-                    self._db = CacheDB(LevelDB(cache_file), cache_size=1024 * 1024)  # type: ignore
+                    self._db = CacheDB(LevelDB(cache_file), cache_size=50 * 1024 * 1024)  # type: ignore
                 except ImportError:
                     # plyvel not found
                     pass


### PR DESCRIPTION
### What I did

- Ensure that `self._db` does not get overridden once its initialized.
- Increase disk cache size from 1 MB to 50 MB 

### How I did it

By only doing db initialization if `_db` attribute was not defined earlier

### How to verify it

Ensure you have `plyvel` installed

```
rm -fvr ~/.cache/titanoboa/fork.db
pytest -s tests/integration/fork/test_abi_contract.py
pytest -s tests/integration/fork/test_abi_contract.py
```

The second run should take significantly less time. For me ~78s vs ~2s

### Description for the changelog

- Fix caching behaviour in CachingRPC, fixes #205
- Increase disk cache to 50MB

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT2H65nVWfY2IebacPFnyKMnhZriEDyXJglWoZJsUMs7oCwXJZzdm6xNTPpiVppEO1aw2s&usqp=CAU)
