### PR TITLE
feat[test]: propagate dev reason to parent stack

### DIFF
--- a/boa/contracts/base_evm_contract.py
+++ b/boa/contracts/base_evm_contract.py
@@ -75,6 +75,11 @@ def _handle_child_trace(computation, env, return_trace):
         child_trace = _trace_for_unknown_contract(child, env)
     else:
         child_trace = child_obj.stack_trace(child)
+
+    if child_trace.last_frame.dev_reason and not return_trace.last_frame.dev_reason:
+        # Propagate the dev reason from the child frame to the parent
+        return_trace.last_frame.dev_reason = child_trace.last_frame.dev_reason
+
     return StackTrace(child_trace + return_trace)
 
 

--- a/tests/unitary/test_reverts.py
+++ b/tests/unitary/test_reverts.py
@@ -185,8 +185,14 @@ def __init__(math: address):
 @external
 def ext_call():
     Math(self.math).some_math(11)
+
+@external
+def ext_call2():
+    Math(self.math).some_math(11)  # dev: call math
 """
     m = boa.loads(pool_code)
     p = boa.loads(math_code, m.address)
     with boa.reverts(dev="math not ok"):
         p.ext_call()
+    with boa.reverts(dev="call math"):
+        p.ext_call2()


### PR DESCRIPTION
### What I did
Fixed https://github.com/vyperlang/titanoboa/issues/199

### How I did it
Copying dev reason to the parent error details

### How to verify it
Test is included

### Description for the changelog
dev reason is now propagated from child contracts so it may be used with `boa.reverts`

### Cute Animal Picture
![image](https://github.com/vyperlang/titanoboa/assets/2369243/fd8e36fd-3bf0-4d05-ac6a-9f42ceaaa2f8)
