### PR TITLE
fix creation of RawEvents

### DIFF
--- a/boa/contracts/vyper/event.py
+++ b/boa/contracts/vyper/event.py
@@ -30,5 +30,6 @@ class Event:
         return f"{self.event_type.name}({args})"
 
 
+@dataclass
 class RawEvent:
     event_data: Any

--- a/tests/integration/fork/test_logs.py
+++ b/tests/integration/fork/test_logs.py
@@ -1,13 +1,17 @@
 import pytest
 
 import boa
+from boa.contracts.vyper.event import RawEvent
+from vyper.utils import keccak256
 
-code = """
+WETH_ADDRESS = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+
+code = f"""
 
 interface IWETH:
     def deposit(): payable
 
-weth9: constant(address) = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+weth9: constant(address) = {WETH_ADDRESS}
 
 @external
 @payable
@@ -24,11 +28,17 @@ def simple_contract():
 
 def test_logs(simple_contract):
     eoa = boa.env.generate_address()
-    boa.env.set_balance(eoa, 10**21)
-    simple_contract.deposit(value=10**18, sender=eoa)
+    amount = 10**18
+    boa.env.set_balance(eoa, amount)
+    simple_contract.deposit(value=amount, sender=eoa)
+
+    topic0 = keccak256("Deposit(address,uint256)".encode())
+    expect_raw_log = (
+        0,
+        int(WETH_ADDRESS, 16).to_bytes(20),
+        (int.from_bytes(topic0), int(simple_contract.address, 16)),
+        amount.to_bytes(32)
+    )
 
     logs = simple_contract.get_logs()
-    assert len(logs) > 0
-
-    for log in logs:
-        assert hasattr(log, "event_data")
+    assert logs == [RawEvent(expect_raw_log)]

--- a/tests/integration/fork/test_logs.py
+++ b/tests/integration/fork/test_logs.py
@@ -1,0 +1,34 @@
+import pytest
+
+import boa
+
+code = """
+
+interface IWETH:
+    def deposit(): payable
+
+weth9: constant(address) = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+
+@external
+@payable
+def deposit():
+    IWETH(weth9).deposit(value=msg.value)
+
+"""
+
+
+@pytest.fixture(scope="module")
+def simple_contract():
+    return boa.loads(code)
+
+
+def test_logs(simple_contract):
+    eoa = boa.env.generate_address()
+    boa.env.set_balance(eoa, 10**21)
+    simple_contract.deposit(value=10**18, sender=eoa)
+
+    logs = simple_contract.get_logs()
+    assert len(logs) > 0
+
+    for log in logs:
+        assert hasattr(log, "event_data")

--- a/tests/integration/fork/test_logs.py
+++ b/tests/integration/fork/test_logs.py
@@ -33,7 +33,7 @@ def test_logs(simple_contract):
     simple_contract.deposit(value=amount, sender=eoa)
 
     topic0 = keccak256("Deposit(address,uint256)".encode())
-    expect_raw_log = (
+    expected_log = (
         0,
         int(WETH_ADDRESS, 16).to_bytes(20),
         (int.from_bytes(topic0), int(simple_contract.address, 16)),
@@ -41,4 +41,4 @@ def test_logs(simple_contract):
     )
 
     logs = simple_contract.get_logs()
-    assert logs == [RawEvent(expect_raw_log)]
+    assert logs == [RawEvent(expected_log)]


### PR DESCRIPTION
### What I did

Fix `TypeError: RawEvent() takes no arguments` occurring while retrieving logs containing unknown events.

### How I did it

* Add missing dataclass decorator to `RawEvent`
* Add test to check the fix

### How to verify it

The test (`tests/integration/fork/test_logs.py`) should pass with the fix and fail without it

### Description for the changelog

### Cute Animal Picture
![lpJdsBz-](https://github.com/vyperlang/titanoboa/assets/9967526/9955e78e-36c7-4b16-a27b-061d658d13ad)

![Put a link to a cute animal picture inside the parenthesis-->]()
