### PR TITLE
fix dynamic_source_filename return for contracts without filename

### DIFF
--- a/boa/coverage.py
+++ b/boa/coverage.py
@@ -68,7 +68,7 @@ class TitanoboaTracer(coverage.plugin.FileTracer):
         if contract is None:
             return None
 
-        return str(contract.filename)
+        return str(contract.filename) if contract.filename else None
 
     def has_dynamic_source_filename(self):
         return True


### PR DESCRIPTION
### What I did

Fix `coverage report` failing with `Plugin 'boa.coverage.TitanoboaPlugin' did not provide a file reporter for 'None'.` Checking with `coverage debug data` shows a line with
```
None: 9 lines [boa.coverage.TitanoboaPlugin]
```

### How I did it

Change `TitanoboaTracer.dynamic_source_filename` to return `None` if there's no contract filename (previously it returned  `"None"`)

### How to verify it

### Description for the changelog

### Cute Animal Picture


![iOne5bBd](https://github.com/vyperlang/titanoboa/assets/9967526/da8bbfdd-c092-4798-ad14-ab48619f83fe)
