### PR TITLE
Update FileInput to match vyper-0.4.0.rc5

### DIFF
--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -129,7 +129,7 @@ def compiler_data(
     global _disk_cache, _search_path
 
     file_input = FileInput(
-        source_code=source_code,
+        contents=source_code,
         source_id=-1,
         path=Path(contract_name),
         resolved_path=Path(filename),


### PR DESCRIPTION
### What I did

Patch inconsistency of `vyper-0.4.0` branch with new vyper version `0.4.0.rc5`.

In vyper the `FileInput` no longer has a `source_code` field:
https://github.com/vyperlang/vyper/blob/75c75c5631222dd1b98c23f8cfeedc080e47a9e3/vyper/compiler/input_bundle.py#L37-L40

### How I did it

I used the contents field.

### How to verify it

Use this example https://github.com/ritzdorf/titanoboa/?tab=readme-ov-file#basic 
It did no longer work.

### Description for the changelog

Adjust `FileInput` usage to match updated `vyper` definition

### Cute Animal Picture

![08_CutestBabyAnimals__Quokkas_shutterstock_1608023803-3960770704](https://github.com/vyperlang/titanoboa/assets/10403309/fc8b4298-7902-4f47-950f-b001e3209bb6)
