### PR TITLE
chore: Update eth-account

### DIFF
--- a/boa/network.py
+++ b/boa/network.py
@@ -495,7 +495,7 @@ class NetworkEnv(Env):
 
             # note: signed.rawTransaction has type HexBytes
             tx_hash = self._rpc.fetch(
-                "eth_sendRawTransaction", [to_hex(bytes(signed.rawTransaction))]
+                "eth_sendRawTransaction", [to_hex(bytes(signed.raw_transaction))]
             )
         else:
             # some providers (i.e. metamask) don't have sign_transaction

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "requests",
 
     # required for networked accounts
-    "eth-account",
+    "eth-account>=0.13.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### What I did
A new version of eth-account released on May 20th has broken our code.
- We are getting the error `'SignedTransaction' object has no attribute 'rawTransaction'` ([example](https://github.com/DanielSchiavini/titanoboa-zksync/actions/runs/9170771752/job/25213666344#step:5:852))
- `rawTransaction` was deprecated in [release 0.12](https://eth-account.readthedocs.io/en/latest/release_notes.html#eth-account-v0-12-0-2024-04-01): https://github.com/ethereum/eth-account/pull/266
- now it was removed in [release 0.13](https://eth-account.readthedocs.io/en/latest/release_notes.html#eth-account-v0-13-0-2024-05-20): https://github.com/ethereum/eth-account/pull/268

### How I did it
- Renamed rawTransaction to raw_transaction
- Updated the requirements list

### How to verify it
- Tests should pass

### Description for the changelog
- Updated eth-account to 0.13

### Cute Animal Picture
![image](https://github.com/vyperlang/titanoboa/assets/2369243/92a2a919-b6ca-4a4e-b6a4-6d9026b97921)
