### PR TITLE
feat: handle constructor stack trace (vyper 0.4)

### DIFF
--- a/boa/contracts/vyper/vyper_contract.py
+++ b/boa/contracts/vyper/vyper_contract.py
@@ -1035,7 +1035,7 @@ class VyperFunction:
             override_bytecode = self._override_bytecode
 
         # note: this anchor doesn't do anything on the default implementation.
-        # it's override the source map in subclasses
+        # the source map is overridden in subclasses
         with self.contract._anchor_source_map(self._source_map):
             computation = self.env.execute_code(
                 to_address=self.contract._address,

--- a/boa/contracts/vyper/vyper_contract.py
+++ b/boa/contracts/vyper/vyper_contract.py
@@ -494,6 +494,7 @@ class VyperContract(_BaseVyperContract):
                 compiler_data.global_ctx.init_function.decl_node, self
             )
 
+        self._address = None
         if skip_initcode:
             if value:
                 raise Exception("nonzero value but initcode is being skipped")
@@ -619,9 +620,11 @@ class VyperContract(_BaseVyperContract):
     def source_map(self):
         if self._source_map is None:
             with anchor_settings(self.compiler_data.settings):
-                _, self._source_map = compile_ir.assembly_to_evm(
-                    self.compiler_data.assembly_runtime
-                )
+                if self._address is None:
+                    assembly = self.compiler_data.assembly
+                else:
+                    assembly = self.compiler_data.assembly_runtime
+                _, self._source_map = compile_ir.assembly_to_evm(assembly)
         return self._source_map
 
     def find_error_meta(self, computation):

--- a/boa/contracts/vyper/vyper_contract.py
+++ b/boa/contracts/vyper/vyper_contract.py
@@ -522,7 +522,6 @@ class VyperContract(_BaseVyperContract):
                 compiler_data.global_ctx.init_function.decl_node, self
             )
 
-        self._address = None
         if skip_initcode:
             if value:
                 raise Exception("nonzero value but initcode is being skipped")

--- a/boa/contracts/vyper/vyper_contract.py
+++ b/boa/contracts/vyper/vyper_contract.py
@@ -711,8 +711,10 @@ class VyperContract(_BaseVyperContract):
 
     @cached_property
     def event_for(self):
-        m = self.compiler_data.vyper_module_folded._metadata["type"]
-        return {e.event_id: e for e in m.events.values()}
+        event_types = [
+            d._metadata["event_type"] for d in self.compiler_data.global_ctx.event_defs
+        ]
+        return {e.event_id: e for e in event_types}
 
     def decode_log(self, e):
         log_id, address, topics, data = e

--- a/tests/unitary/test_logs.py
+++ b/tests/unitary/test_logs.py
@@ -9,7 +9,7 @@ event Transfer:
     receiver: indexed(address)
     value: uint256
 
-@external
+@deploy
 def __init__(supply: uint256):
     log Transfer(empty(address), msg.sender, supply)
 """,


### PR DESCRIPTION
This PR is similar to https://github.com/vyperlang/titanoboa/pull/228 however it targets the 0.4.0 branch. Vyper >=0.4.0-rc4 also has source maps for constructors (since https://github.com/vyperlang/vyper/pull/4008).

### What I did
- Fix and test exceptions during contract construction

### How I did it
- Use 'assembly' instead of 'assembly_runtime' source map during the constructor
- Add tests

### How to verify it
- Tests are included

### Description for the changelog
- reverts in constructors have proper stack traces

### Cute Animal Picture
![image](https://github.com/vyperlang/titanoboa/assets/2369243/f54fd841-d9b9-4366-a461-7a4bb3c3a38f)
