### PR TITLE
fix race in disk cache

### DIFF
--- a/boa/util/disk_cache.py
+++ b/boa/util/disk_cache.py
@@ -66,7 +66,7 @@ class DiskCache:
                 return pickle.loads(f.read())
         except OSError:
             res = func()
-            # note: how portable is os.getpid()? should we use uuid generator?
+            # use process ID and thread ID to avoid race conditions
             job_id = f"{os.getpid()}.{threading.get_ident()}"
             tmp_p = p.with_suffix(f".{job_id}.unfinished")
             with tmp_p.open("wb") as f:

--- a/boa/util/disk_cache.py
+++ b/boa/util/disk_cache.py
@@ -66,8 +66,9 @@ class DiskCache:
                 return pickle.loads(f.read())
         except OSError:
             res = func()
-            tid = threading.get_ident()
-            tmp_p = p.with_suffix(f".{tid}.unfinished")
+            # note: how portable is os.getpid()? should we use uuid generator?
+            job_id = f"{os.getpid()}.{threading.get_ident()}"
+            tmp_p = p.with_suffix(f".{job_id}.unfinished")
             with tmp_p.open("wb") as f:
                 f.write(pickle.dumps(res))
             # rename is atomic, don't really need to care about fsync


### PR DESCRIPTION
apparently with xdist, multiple processes can allocate the same thread id

### What I did

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
