### PR TITLE
fix[cache]: add contract name to cache key

### DIFF
--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -96,7 +96,8 @@ def compiler_data(source_code: str, contract_name: str, **kwargs) -> CompilerDat
             _ = ret.bytecode, ret.bytecode_runtime  # force compilation to happen
         return ret
 
-    return _disk_cache.caching_lookup(str((kwargs, source_code)), func)
+    cache_key = str((contract_name, source_code, kwargs))
+    return _disk_cache.caching_lookup(cache_key, func)
 
 
 def load(filename: str | Path, *args, **kwargs) -> _Contract:  # type: ignore

--- a/tests/unitary/utils/test_cache.py
+++ b/tests/unitary/utils/test_cache.py
@@ -1,0 +1,15 @@
+from boa.interpret import _disk_cache, compiler_data
+
+
+def test_cache_contract_name():
+    code = """
+x: constant(int128) = 1000
+"""
+    assert _disk_cache is not None
+    test1 = compiler_data(code, "test1")
+    test2 = compiler_data(code, "test2")
+    assert (
+        test1.__dict__ == compiler_data(code, "test1").__dict__
+    ), "Should hit the cache"
+    assert test1.__dict__ != test2.__dict__, "Should be different objects"
+    assert test2.contract_name == "test2"


### PR DESCRIPTION
that could lead to confusing error messages in case a contract is deployed twice with the same source code.

### What I did
- add contact name to cache key

### How to verify it
- The cache should not return the same object when the contract name is different.

### Description for the changelog
- fix: cache should be ignored when compiling with a different contract name

### Cute Animal Picture
![image](https://github.com/vyperlang/titanoboa/assets/2369243/8a2ea477-2941-4e9f-9c23-b92c4fb59749)
