### PR TITLE
improve profiling output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ venv/
 
 .coverage
 .coverage.*
+.DS_Store

--- a/boa/profiling.py
+++ b/boa/profiling.py
@@ -11,12 +11,13 @@ from boa.contracts.vyper.ast_utils import get_fn_name_from_lineno, get_line
 from boa.environment import Env
 
 
-def safe_relpath(path):
+def _safe_relpath(path):
     try:
-        relpath = os.path.relpath(path)
-    except ValueError:  # for Windows, if path is not on os.curdir
-        relpath = ""
-    return relpath
+        return os.path.relpath(path)
+    except ValueError:
+        # on Windows, if path and curdir are on different drives, an exception
+        # can be thrown
+        return path
 
 
 @dataclass(unsafe_hash=True)
@@ -339,7 +340,7 @@ def get_call_profile_table(env: Env) -> Table:
             fn_name = profile.fn_name
             stats = list(stats.net_gas_stats.get_str_repr())
             if c == 0:
-                relpath = safe_relpath(profile.contract_name)
+                relpath = _safe_relpath(profile.contract_name)
                 contract_data_str = (
                     f"Path: {os.path.dirname(relpath)}\n"
                     f"Name: {os.path.basename(relpath)}\n"
@@ -370,7 +371,7 @@ def get_line_profile_table(env: Env) -> Table:
 
     table = _create_table(for_line_profile=True)
     for (contract_name, contract_address), fn_data in contracts.items():
-        relpath = safe_relpath(contract_name)
+        relpath = _safe_relpath(contract_name)
         contract_data_str = (
             f"Path: {os.path.dirname(relpath)}\n"
             f"Name: {os.path.basename(relpath)}\n"

--- a/boa/profiling.py
+++ b/boa/profiling.py
@@ -11,6 +11,14 @@ from boa.contracts.vyper.ast_utils import get_fn_name_from_lineno, get_line
 from boa.environment import Env
 
 
+def safe_relpath(path):
+    try:
+        relpath = os.path.relpath(path)
+    except ValueError:  # for Windows, if path is not on os.curdir
+        relpath = ""
+    return relpath
+
+
 @dataclass(unsafe_hash=True)
 class LineInfo:
     address: str
@@ -331,7 +339,7 @@ def get_call_profile_table(env: Env) -> Table:
             fn_name = profile.fn_name
             stats = list(stats.net_gas_stats.get_str_repr())
             if c == 0:
-                relpath = os.path.relpath(profile.contract_name)
+                relpath = safe_relpath(profile.contract_name)
                 contract_data_str = (
                     f"Path: {os.path.dirname(relpath)}\n"
                     f"Name: {os.path.basename(relpath)}\n"
@@ -362,7 +370,7 @@ def get_line_profile_table(env: Env) -> Table:
 
     table = _create_table(for_line_profile=True)
     for (contract_name, contract_address), fn_data in contracts.items():
-        relpath = os.path.relpath(contract_name)
+        relpath = safe_relpath(contract_name)
         contract_data_str = (
             f"Path: {os.path.dirname(relpath)}\n"
             f"Name: {os.path.basename(relpath)}\n"

--- a/boa/profiling.py
+++ b/boa/profiling.py
@@ -275,14 +275,16 @@ def cache_gas_used_for_computation(contract, computation):
 def _create_table(for_line_profile: bool = False) -> Table:
     table = Table(title="\n")
 
-    table.add_column(
-        "Contract", justify="left", style="cyan", no_wrap=True, width=52
-    )
+    table.add_column("Contract", justify="left", style="cyan", no_wrap=True, width=52)
     computation_column_width = 30
     if for_line_profile:
         computation_column_width = 79
     table.add_column(
-        "Computation", justify="left", style="cyan", no_wrap=True, width=computation_column_width
+        "Computation",
+        justify="left",
+        style="cyan",
+        no_wrap=True,
+        width=computation_column_width,
     )
 
     table.add_column("Count", style="magenta")
@@ -319,7 +321,7 @@ def get_call_profile_table(env: Env) -> Table:
             fn_vs_median_gas.append((cache[profile].net_gas_stats.median_gas, profile))
 
         # arrange from most to least expensive contracts:
-        fn_vs_mfn_vs_median_gasean_gas = sorted(fn_vs_median_gas, key=lambda x: x[0], reverse=True)
+        fn_vs_median_gas = sorted(fn_vs_median_gas, key=lambda x: x[0], reverse=True)
 
         for c, (_, profile) in enumerate(fn_vs_median_gas):
             stats = cache[profile]


### PR DESCRIPTION
update view; arrange profiling table on median and not mean (so users can ignore storage slot writes and look at computations instead)

### What I did

call profile column looks like the following:

<img width="971" alt="image" src="https://github.com/vyperlang/titanoboa/assets/11488427/ec61b2f4-32e1-4a11-9144-a98e47b30fa8">

1. one less column (no address column. it's all in column 1)
2. paths are shorter
3. values are arranged based on median gas costs and not average gas costs

profiling table looks like:

<img width="1338" alt="image" src="https://github.com/vyperlang/titanoboa/assets/11488427/4064a48f-fcdd-4e4b-ba2f-4aa606b2dc38">

1. paths are shorter
2. values are arranged based on median gas costs

arranging by median means storage reads and writes do not populate the top of the table. this is much better when it comes to looking for computations to optimise.

### How I did it

very simple code changes

### How to verify it

run a profiling test

### Description for the changelog

improve profiling table view and arrange data by median gas costs

### Cute Animal Picture

![image](https://github.com/vyperlang/titanoboa/assets/11488427/9406fd8a-2005-47b6-94a2-22fe812acc87)
