### PR TITLE
feat: cache network deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ def foo() -> uint256:
 ```python
 In [1]: %load_ext boa.ipython
         import boa
-        boa.interpret.set_cache_dir()  # cache source compilations across sessions
 
 In [2]: %vyper msg.sender  # evaluate a vyper expression directly
 Out[2]: '0x0000000000000000000000000000000000000065'

--- a/boa/contracts/vyper/vyper_contract.py
+++ b/boa/contracts/vyper/vyper_contract.py
@@ -533,10 +533,7 @@ class VyperContract(_BaseVyperContract):
 
         initcode = self.compiler_data.bytecode + encoded_args
         address, computation = self.env.deploy(
-            bytecode=initcode,
-            value=value,
-            override_address=override_address,
-            source_code=self.compiler_data.source_code,
+            bytecode=initcode, value=value, override_address=override_address
         )
         self._computation = computation
         self.bytecode = computation.output

--- a/boa/contracts/vyper/vyper_contract.py
+++ b/boa/contracts/vyper/vyper_contract.py
@@ -533,7 +533,10 @@ class VyperContract(_BaseVyperContract):
 
         initcode = self.compiler_data.bytecode + encoded_args
         address, computation = self.env.deploy(
-            bytecode=initcode, value=value, override_address=override_address
+            bytecode=initcode,
+            value=value,
+            override_address=override_address,
+            source_code=self.compiler_data.source_code,
         )
         self._computation = computation
         self.bytecode = computation.output

--- a/boa/environment.py
+++ b/boa/environment.py
@@ -200,6 +200,7 @@ class Env:
         gas: Optional[int] = None,
         value: int = 0,
         bytecode: bytes = b"",
+        source_code: Optional[str] = None,
         start_pc: int = 0,  # TODO: This isn't used
         # override the target address:
         override_address: Optional[_AddressType] = None,
@@ -313,6 +314,9 @@ class Env:
                 continue
             child_contract = self._lookup_contract_fast(child.msg.code_address)
             self._hook_trace_computation(child, child_contract)
+
+    def get_chain_id(self) -> int:
+        return self.evm.chain.chain_id
 
     def get_code(self, address: _AddressType) -> bytes:
         return self.evm.get_code(Address(address))

--- a/boa/environment.py
+++ b/boa/environment.py
@@ -200,7 +200,7 @@ class Env:
         gas: Optional[int] = None,
         value: int = 0,
         bytecode: bytes = b"",
-        source_code: Optional[str] = None,
+        source_code: Optional[str] = None,  # only used in network env
         start_pc: int = 0,  # TODO: This isn't used
         # override the target address:
         override_address: Optional[_AddressType] = None,

--- a/boa/integrations/jupyter/browser.py
+++ b/boa/integrations/jupyter/browser.py
@@ -139,12 +139,6 @@ class BrowserEnv(NetworkEnv):
         self.signer = BrowserSigner(address)
         self.set_eoa(self.signer)
 
-    def get_chain_id(self) -> int:
-        chain_id = _javascript_call(
-            "rpc", "eth_chainId", timeout_message=RPC_TIMEOUT_MESSAGE
-        )
-        return int.from_bytes(bytes.fromhex(chain_id[2:]), "big")
-
     def set_chain_id(self, chain_id: int | str):
         _javascript_call(
             "rpc",

--- a/boa/network.py
+++ b/boa/network.py
@@ -23,8 +23,6 @@ from boa.rpc import (
 from boa.util.abi import Address
 from boa.util.deploy_cache import DeployCache
 
-_deploy_cache_path = Path("~/.local/share/titanoboa/deploy_cache.sqlite").expanduser()
-
 
 class TraceObject:
     def __init__(self, raw_trace):
@@ -149,6 +147,9 @@ class NetworkEnv(Env):
 
     # always prefetch state in network mode
     _fork_try_prefetch_state = True
+    _deploy_cache_path = Path(
+        "~/.local/share/titanoboa/deploy_cache.sqlite"
+    ).expanduser()
 
     def __init__(
         self,
@@ -365,7 +366,7 @@ class NetworkEnv(Env):
         **kwargs,
     ):
         if trim_dict(kwargs):
-            raise TypeError(f"invalid kwargs to execute_code: {kwargs}")
+            raise TypeError(f"invalid kwargs to `deploy`: {kwargs}")
 
         # todo: use integrity hash instead of source code after vyper>=0.4
         # note: bytecode already includes the constructor args
@@ -416,7 +417,7 @@ class NetworkEnv(Env):
 
     @cached_property
     def _deploys(self):
-        return DeployCache(_deploy_cache_path)
+        return DeployCache(self._deploy_cache_path)
 
     @cached_property
     def _tracer(self):

--- a/boa/network.py
+++ b/boa/network.py
@@ -422,8 +422,13 @@ class NetworkEnv(Env):
         if DeployCache.has(cache_key):  # get address before deploying to evm
             receipt, trace = DeployCache.lookup(cache_key, send_tx)
             address = Address(receipt["contractAddress"])
-            if self.get_code(address) in bytecode:
+            code = self.get_code(address)
+            if code and code in bytecode:
                 return address, receipt, trace
+            else:
+                # in test chains (e.g. anvil) the bytecode is lost on restart
+                assert code == b"", f"code mismatch: {code} != {bytecode}"
+
         return None, None, None
 
     @cached_property

--- a/boa/util/deploy_cache.py
+++ b/boa/util/deploy_cache.py
@@ -1,0 +1,70 @@
+import json
+from functools import cached_property
+from hashlib import sha256
+from sqlite3 import connect
+
+
+class DeployCache:
+    def __init__(self, path):
+        self.path = path
+
+    @cached_property
+    def connection(self):
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        connection = connect(self.path)
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS deploy_cache (
+            deploy_id TEXT PRIMARY KEY,
+            hash TEXT,
+            receipt TEXT,
+            trace TEXT
+            )
+        """
+        )
+        return connection
+
+    def get(self, source_code, bytecode, deploy_id, chain_id):
+        receipt, trace = None, None
+        if deploy_id and source_code:
+            hashed = self._get_hash(bytecode, deploy_id, source_code, chain_id)
+            row = self._get(deploy_id, hashed)
+            if row:
+                receipt = json.loads(row["receipt"])
+                from boa.network import TraceObject
+
+                trace = TraceObject(json.loads(row["trace"]))
+
+        return receipt, trace
+
+    def _get(self, deploy_id, hashed):
+        cursor = self.connection.cursor()
+        cursor.execute(
+            """
+            SELECT receipt, trace
+            FROM deploy_cache
+            WHERE deploy_id = ? AND hash = ?
+        """,
+            (deploy_id, hashed),
+        )
+        return cursor.fetchone()
+
+    def _get_hash(self, bytecode, deploy_id, source_code, chain_id):
+        return (
+            sha256(str((source_code, bytecode, deploy_id, chain_id)).encode())
+            .digest()
+            .hex()
+        )
+
+    def set(self, source_code, bytecode, deploy_id, chain_id, receipt, trace):
+        if deploy_id and source_code:
+            hashed = self._get_hash(bytecode, deploy_id, source_code, chain_id)
+            self._insert(deploy_id, hashed, receipt, trace)
+
+    def _insert(self, deploy_id, hashed, receipt, trace):
+        cursor = self.connection.cursor()
+        cursor.execute(
+            "INSERT INTO deploy_cache VALUES (?, ?, ?, ?)",
+            (deploy_id, hashed, json.dumps(receipt), json.dumps(trace.raw_trace)),
+        )
+        self.connection.commit()

--- a/boa/util/deploy_cache.py
+++ b/boa/util/deploy_cache.py
@@ -1,41 +1,61 @@
 import json
 from functools import cached_property
 from hashlib import sha256
+from pathlib import Path
 from sqlite3 import connect
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from boa.network import TraceObject
 
 
 class DeployCache:
-    def __init__(self, path):
+    """
+    A cache for storing deploy information.
+    """
+
+    def __init__(self, path: Path):
         self.path = path
 
     @cached_property
     def connection(self):
         self.path.parent.mkdir(parents=True, exist_ok=True)
         connection = connect(self.path)
+        # return results as dictionaries
+        connection.row_factory = lambda cursor, row: {
+            column[0]: row[index] for index, column in enumerate(cursor.description)
+        }
         connection.execute(
             """
             CREATE TABLE IF NOT EXISTS deploy_cache (
-            deploy_id TEXT PRIMARY KEY,
-            hash TEXT,
-            receipt TEXT,
-            trace TEXT
+                deploy_id TEXT, hash TEXT, -- cache key
+                receipt TEXT, trace TEXT, -- cache value
+                PRIMARY KEY(deploy_id, hash)
             )
         """
         )
         return connection
 
-    def get(self, source_code, bytecode, deploy_id, chain_id):
-        receipt, trace = None, None
+    def get(
+        self, source_code: str, bytecode: bytes, deploy_id: str, chain_id: int
+    ) -> tuple[dict, "TraceObject"] | tuple[None, None]:
+        if not deploy_id or not source_code:
+            return None, None
+
+        hash_str = self._hash_str(bytecode, source_code, chain_id)
+        if (row := self._get(deploy_id, hash_str)) is None:
+            print(bytecode.hex())
+            return None, None
+
+        from boa.network import TraceObject
+
+        return json.loads(row["receipt"]), TraceObject(json.loads(row["trace"]))
+
+    def set(self, source_code, bytecode, deploy_id, chain_id, receipt, trace):
         if deploy_id and source_code:
-            hashed = self._get_hash(bytecode, deploy_id, source_code, chain_id)
-            row = self._get(deploy_id, hashed)
-            if row:
-                receipt = json.loads(row["receipt"])
-                from boa.network import TraceObject
-
-                trace = TraceObject(json.loads(row["trace"]))
-
-        return receipt, trace
+            hash_str = self._hash_str(bytecode, source_code, chain_id)
+            print(bytecode.hex())
+            self._insert(deploy_id, hash_str, receipt, trace)
 
     def _get(self, deploy_id, hashed):
         cursor = self.connection.cursor()
@@ -49,17 +69,9 @@ class DeployCache:
         )
         return cursor.fetchone()
 
-    def _get_hash(self, bytecode, deploy_id, source_code, chain_id):
-        return (
-            sha256(str((source_code, bytecode, deploy_id, chain_id)).encode())
-            .digest()
-            .hex()
-        )
-
-    def set(self, source_code, bytecode, deploy_id, chain_id, receipt, trace):
-        if deploy_id and source_code:
-            hashed = self._get_hash(bytecode, deploy_id, source_code, chain_id)
-            self._insert(deploy_id, hashed, receipt, trace)
+    def _hash_str(self, bytecode: bytes, source_code: str, chain_id: int) -> str:
+        key = source_code, bytecode, chain_id
+        return sha256(str(key).encode()).digest().hex()
 
     def _insert(self, deploy_id, hashed, receipt, trace):
         cursor = self.connection.cursor()

--- a/boa/util/deploy_cache.py
+++ b/boa/util/deploy_cache.py
@@ -44,7 +44,6 @@ class DeployCache:
 
         hash_str = self._hash_str(bytecode, source_code, chain_id)
         if (row := self._get(deploy_id, hash_str)) is None:
-            print(bytecode.hex())
             return None, None
 
         from boa.network import TraceObject
@@ -54,7 +53,6 @@ class DeployCache:
     def set(self, source_code, bytecode, deploy_id, chain_id, receipt, trace):
         if deploy_id and source_code:
             hash_str = self._hash_str(bytecode, source_code, chain_id)
-            print(bytecode.hex())
             self._insert(deploy_id, hash_str, receipt, trace)
 
     def _get(self, deploy_id, hashed):

--- a/boa/util/disk_cache.py
+++ b/boa/util/disk_cache.py
@@ -5,13 +5,6 @@ import pickle
 import threading
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Generic, Optional, TypeVar
-
-from vyper.compiler import CompilerData
-
-if TYPE_CHECKING:
-    from boa.network import TraceObject
-
 
 _ONE_WEEK = 7 * 24 * 3600
 
@@ -27,19 +20,15 @@ def _silence_io_errors():
         pass
 
 
-T = TypeVar("T")
-
-
-class _DiskCache(Generic[T]):
-    _instance: Optional["_DiskCache"] = None
-
-    def __init__(self, cache_dir: str | Path, version_salt: str, ttl=_ONE_WEEK):
+class DiskCache:
+    def __init__(self, cache_dir, version_salt, ttl=_ONE_WEEK):
         self.cache_dir = Path(cache_dir).expanduser()
         self.version_salt = version_salt
-        self.ttl = ttl  # time to live
-        self.last_gc = 0.0  # last garbage collection
+        self.ttl = ttl
 
-    def _collect_garbage(self, force=False) -> None:
+        self.last_gc = 0
+
+    def gc(self, force=False):
         for root, dirs, files in os.walk(self.cache_dir):
             # delete items older than ttl
             for f in files:
@@ -59,18 +48,18 @@ class _DiskCache(Generic[T]):
         self.last_gc = time.time()
 
     # content-addressable location
-    def _get_location(self, key: str) -> Path:
-        preimage = (self.version_salt + key).encode("utf-8")
+    def cal(self, string):
+        preimage = (self.version_salt + string).encode("utf-8")
         digest = hashlib.sha256(preimage).digest().hex()
         return self.cache_dir.joinpath(f"{self.version_salt}/{digest}.pickle")
 
     # look up x in the cal; on a miss, write back to the cache
-    def _lookup(self, key: str, func: Callable[[], T]) -> T:
+    def caching_lookup(self, string, func):
         gc_interval = self.ttl // 10
         if time.time() - self.last_gc >= gc_interval:
-            self._collect_garbage()
+            self.gc()
 
-        p = self._get_location(key)
+        p = self.cal(string)
         p.parent.mkdir(parents=True, exist_ok=True)
         try:
             with p.open("rb") as f:
@@ -88,37 +77,3 @@ class _DiskCache(Generic[T]):
         # because worst case we will just rebuild the item
         tmp_p.rename(p)
         return res
-
-    @classmethod
-    def has(cls, key: str) -> bool | None:
-        """
-        Check if the cache contains the given key.
-        :param key: The key to check
-        :return: None if cache is disabled, True if key is in cache, False otherwise
-        """
-        if cls._instance is None:
-            return None
-        return cls._instance._get_location(key).exists()
-
-    @classmethod
-    def lookup(cls, key: str, func: Callable[[], T]) -> T:
-        """
-        Lookup the string in the cache, if it is not found, call the function to get the value.
-        :param key: The string to look up
-        :param func: The function to call if the string is not found
-        :return: The value and whether it was found in the cache:
-            - True if the value was found in the cache
-            - False if the value was added to the cache
-            - None if the cache is disabled
-        """
-        if cls._instance is None:
-            return func()
-        return cls._instance._lookup(key, func)
-
-
-class CompileCache(_DiskCache[CompilerData]):
-    _instance: Optional["CompileCache"] = None
-
-
-class DeployCache(_DiskCache[tuple[dict, Optional["TraceObject"]]]):
-    _instance: Optional["DeployCache"] = None

--- a/tests/integration/network/anvil/conftest.py
+++ b/tests/integration/network/anvil/conftest.py
@@ -3,6 +3,7 @@
 import subprocess
 import sys
 import time
+from shutil import rmtree
 
 import pytest
 import requests
@@ -75,8 +76,13 @@ def anvil_env(free_port):
 # XXX: maybe parametrize across anvil, hardhat and geth --dev for
 # max coverage across VM implementations?
 @pytest.fixture(scope="module", autouse=True)
-def networked_env(accounts, anvil_env):
+def networked_env(accounts, anvil_env, tmp_path_factory):
+    tmp_path = tmp_path_factory.mktemp(
+        "anvil"
+    )  # normal tmp_path fixture is function-scoped
+    anvil_env._deploy_cache_path = tmp_path / "deploy_cache.sqlite"
     with boa.swap_env(anvil_env):
         for account in accounts:
             boa.env.add_account(account)
         yield
+    rmtree(tmp_path)

--- a/tests/integration/network/anvil/test_network_env.py
+++ b/tests/integration/network/anvil/test_network_env.py
@@ -1,3 +1,6 @@
+from os import urandom
+from unittest.mock import patch
+
 import pytest
 from hypothesis import given, settings
 
@@ -54,6 +57,30 @@ def test_update_total_supply(simple_contract, t):
 def test_raise_exception(simple_contract, t):
     with boa.reverts("oh no!"):
         simple_contract.raise_exception(t)
+
+
+def test_deploy_cached():
+    deploy_id = urandom(16).hex()
+    c1 = boa.loads(code, STARTING_SUPPLY, deploy_id=deploy_id)
+    with patch("boa.network.NetworkEnv._send_txn", side_effect=ValueError):
+        c2 = boa.loads(code, STARTING_SUPPLY, deploy_id=deploy_id)
+
+    # different supply
+    c3 = boa.loads(code, STARTING_SUPPLY * 2, deploy_id=deploy_id)
+
+    assert c1.address == c2.address
+    assert c1.address != c3.address
+
+
+def test_deploy_cache_set():
+    deploy_id = urandom(16).hex()
+    deployer = boa.loads_partial(code)
+    c1 = deployer.deploy(STARTING_SUPPLY, deploy_id=deploy_id)
+    bytecode = deployer.compiler_data.bytecode + c1._ctor.prepare_calldata(
+        STARTING_SUPPLY
+    )
+    receipt, trace = boa.env._deploys.get(code, bytecode, deploy_id, chain_id=31337)
+    assert receipt is not None and trace is not None
 
 
 # XXX: probably want to test deployment revert behavior

--- a/tests/integration/network/anvil/test_network_env.py
+++ b/tests/integration/network/anvil/test_network_env.py
@@ -31,11 +31,6 @@ def simple_contract():
     return boa.loads(code, STARTING_SUPPLY)
 
 
-def test_env_type():
-    # sanity check
-    assert isinstance(boa.env, NetworkEnv)
-
-
 def test_total_supply(simple_contract):
     assert simple_contract.totalSupply() == STARTING_SUPPLY
 
@@ -54,6 +49,11 @@ def test_update_total_supply(simple_contract, t):
 def test_raise_exception(simple_contract, t):
     with boa.reverts("oh no!"):
         simple_contract.raise_exception(t)
+
+
+def test_env_type():
+    # sanity check
+    assert isinstance(boa.env, NetworkEnv)
 
 
 # XXX: probably want to test deployment revert behavior

--- a/tests/integration/network/anvil/test_network_env.py
+++ b/tests/integration/network/anvil/test_network_env.py
@@ -31,6 +31,11 @@ def simple_contract():
     return boa.loads(code, STARTING_SUPPLY)
 
 
+def test_env_type():
+    # sanity check
+    assert isinstance(boa.env, NetworkEnv)
+
+
 def test_total_supply(simple_contract):
     assert simple_contract.totalSupply() == STARTING_SUPPLY
 
@@ -49,11 +54,6 @@ def test_update_total_supply(simple_contract, t):
 def test_raise_exception(simple_contract, t):
     with boa.reverts("oh no!"):
         simple_contract.raise_exception(t)
-
-
-def test_env_type():
-    # sanity check
-    assert isinstance(boa.env, NetworkEnv)
 
 
 # XXX: probably want to test deployment revert behavior

--- a/tests/unitary/utils/test_disk_cache.py
+++ b/tests/unitary/utils/test_disk_cache.py
@@ -1,0 +1,54 @@
+from shutil import rmtree
+
+import pytest
+
+from boa.util.disk_cache import DiskCache
+
+
+def cache_miss():
+    return "value"
+
+
+@pytest.fixture
+def cache(tmp_path):
+    cache_dir = tmp_path / "test_cache"
+    cache_dir.mkdir()
+    cache = DiskCache(str(cache_dir), "version_salt")
+    DiskCache._instance, old_cache = cache, DiskCache._instance
+    yield cache
+    rmtree(cache_dir)
+    DiskCache._instance = old_cache
+
+
+def test_init(cache):
+    assert cache.cache_dir.exists()
+    assert cache.version_salt == "version_salt"
+    assert cache.ttl == 7 * 24 * 3600  # default ttl
+    assert cache.last_gc == 0
+
+
+def test_collect_garbage(cache):
+    assert DiskCache.lookup("key", cache_miss)
+    cache._collect_garbage(force=True)
+    assert cache.last_gc > 0
+
+
+def test__get_location(cache):
+    path = cache._get_location("key")
+    assert "version_salt" in str(path)
+    assert ".pickle" in str(path)
+
+
+def test_contains(cache):
+    assert DiskCache.has("key") is False
+    assert DiskCache.lookup("key", cache_miss) == ("value", False)
+    assert DiskCache.has("key") is True
+    assert DiskCache.lookup("key", cache_miss) == ("value", True)
+
+
+def test_no_cache(cache):
+    DiskCache._instance = None
+    assert DiskCache.lookup("key", cache_miss) == ("value", None)
+    assert DiskCache.lookup("key", cache_miss) == ("value", None)
+    assert DiskCache.has("key") is None
+    DiskCache._instance = cache

--- a/tests/unitary/utils/test_disk_cache.py
+++ b/tests/unitary/utils/test_disk_cache.py
@@ -2,22 +2,30 @@ from shutil import rmtree
 
 import pytest
 
-from boa.util.disk_cache import DiskCache
+from boa.interpret import compiler_data
+from boa.util.disk_cache import CompileCache, DeployCache
+
+_dummy = compiler_data("", "")
 
 
 def cache_miss():
-    return "value"
+    return _dummy
 
 
 @pytest.fixture
 def cache(tmp_path):
     cache_dir = tmp_path / "test_cache"
     cache_dir.mkdir()
-    cache = DiskCache(str(cache_dir), "version_salt")
-    DiskCache._instance, old_cache = cache, DiskCache._instance
+    cache = CompileCache(str(cache_dir), "version_salt")
+    CompileCache._instance, old_cache = cache, CompileCache._instance
     yield cache
     rmtree(cache_dir)
-    DiskCache._instance = old_cache
+    CompileCache._instance = old_cache
+
+
+def test_deploy_cache_separate_instance(cache):
+    assert CompileCache._instance == cache
+    assert DeployCache._instance != cache
 
 
 def test_init(cache):
@@ -28,7 +36,7 @@ def test_init(cache):
 
 
 def test_collect_garbage(cache):
-    assert DiskCache.lookup("key", cache_miss)
+    assert CompileCache.lookup("key", cache_miss)
     cache._collect_garbage(force=True)
     assert cache.last_gc > 0
 
@@ -40,15 +48,16 @@ def test__get_location(cache):
 
 
 def test_contains(cache):
-    assert DiskCache.has("key") is False
-    assert DiskCache.lookup("key", cache_miss) == ("value", False)
-    assert DiskCache.has("key") is True
-    assert DiskCache.lookup("key", cache_miss) == ("value", True)
+    assert CompileCache.has("key") is False
+    assert CompileCache.lookup("key", cache_miss) == _dummy
+    assert CompileCache.has("key") is True
+    assert CompileCache.lookup("key", cache_miss).__dict__ == _dummy.__dict__
 
 
 def test_no_cache(cache):
-    DiskCache._instance = None
-    assert DiskCache.lookup("key", cache_miss) == ("value", None)
-    assert DiskCache.lookup("key", cache_miss) == ("value", None)
-    assert DiskCache.has("key") is None
-    DiskCache._instance = cache
+    CompileCache._instance = None
+    assert CompileCache.lookup("key", cache_miss) == _dummy
+    with pytest.raises(TypeError):
+        CompileCache.lookup("key", {})
+    assert CompileCache.has("key") is None
+    CompileCache._instance = cache

--- a/tests/unitary/utils/test_disk_cache.py
+++ b/tests/unitary/utils/test_disk_cache.py
@@ -3,7 +3,7 @@ from shutil import rmtree
 import pytest
 
 from boa.interpret import compiler_data
-from boa.util.disk_cache import CompileCache, DeployCache
+from boa.util.disk_cache import DiskCache
 
 _dummy = compiler_data("", "")
 
@@ -16,16 +16,9 @@ def cache_miss():
 def cache(tmp_path):
     cache_dir = tmp_path / "test_cache"
     cache_dir.mkdir()
-    cache = CompileCache(str(cache_dir), "version_salt")
-    CompileCache._instance, old_cache = cache, CompileCache._instance
+    cache = DiskCache(str(cache_dir), "version_salt")
     yield cache
     rmtree(cache_dir)
-    CompileCache._instance = old_cache
-
-
-def test_deploy_cache_separate_instance(cache):
-    assert CompileCache._instance == cache
-    assert DeployCache._instance != cache
 
 
 def test_init(cache):
@@ -36,28 +29,20 @@ def test_init(cache):
 
 
 def test_collect_garbage(cache):
-    assert CompileCache.lookup("key", cache_miss)
-    cache._collect_garbage(force=True)
+    assert cache.caching_lookup("key", cache_miss)
+    cache.gc(force=True)
     assert cache.last_gc > 0
 
 
 def test__get_location(cache):
-    path = cache._get_location("key")
+    path = cache.cal("key")
     assert "version_salt" in str(path)
     assert ".pickle" in str(path)
 
 
 def test_contains(cache):
-    assert CompileCache.has("key") is False
-    assert CompileCache.lookup("key", cache_miss) == _dummy
-    assert CompileCache.has("key") is True
-    assert CompileCache.lookup("key", cache_miss).__dict__ == _dummy.__dict__
-
-
-def test_no_cache(cache):
-    CompileCache._instance = None
-    assert CompileCache.lookup("key", cache_miss) == _dummy
-    with pytest.raises(TypeError):
-        CompileCache.lookup("key", {})
-    assert CompileCache.has("key") is None
-    CompileCache._instance = cache
+    first = cache.caching_lookup("key", cache_miss)
+    assert first == _dummy
+    second = cache.caching_lookup("key", cache_miss)
+    assert second.__dict__ == _dummy.__dict__
+    assert first is not second, "should not be the same object given serialization"


### PR DESCRIPTION
Fixes #82 and #231

### What I did
Updated the existing cache mechanism to also cache deployments to the network.

### How I did it
- Implement a cache in sqlite DB
- When the user passes a `deploy_id` to a network deployment:
  - The network env first checks whether the deployment was done before
  - If so: The deployment is done again to pyevm, but not to the RPC
  - Otherwise: The deployment is done to both pyevm and RPC, and saved in the DB
- The cache key is `sha256(source_code, bytecode, chain_id) + deploy_id`

### How to verify it
- Tests are included

### Description for the changelog
- Allow deployments to be restarted by passing a `deploy_id`

### Cute Animal Picture
![image](https://github.com/vyperlang/titanoboa/assets/2369243/1b975ec7-1318-4412-8efd-b62b99d8115c)
