### PR TITLE
fix: confusing stack trace

### DIFF
--- a/boa/util/disk_cache.py
+++ b/boa/util/disk_cache.py
@@ -65,13 +65,15 @@ class DiskCache:
             with p.open("rb") as f:
                 return pickle.loads(f.read())
         except OSError:
-            res = func()
-            # use process ID and thread ID to avoid race conditions
-            job_id = f"{os.getpid()}.{threading.get_ident()}"
-            tmp_p = p.with_suffix(f".{job_id}.unfinished")
-            with tmp_p.open("wb") as f:
-                f.write(pickle.dumps(res))
-            # rename is atomic, don't really need to care about fsync
-            # because worst case we will just rebuild the item
-            tmp_p.rename(p)
-            return res
+            pass  # discard the stack trace in case of other errors
+
+        res = func()
+        # use process ID and thread ID to avoid race conditions
+        job_id = f"{os.getpid()}.{threading.get_ident()}"
+        tmp_p = p.with_suffix(f".{job_id}.unfinished")
+        with tmp_p.open("wb") as f:
+            f.write(pickle.dumps(res))
+        # rename is atomic, don't really need to care about fsync
+        # because worst case we will just rebuild the item
+        tmp_p.rename(p)
+        return res


### PR DESCRIPTION
When errors occur during the contract compilation, we currently get:
```
FileNotFoundError: [Errno 2] No such file or directory: '...'
During handling of the above exception, another exception occurred: ...
```

This PR should change the stack to show the real issue.

### Cute Animal Picture
![image](https://github.com/vyperlang/titanoboa/assets/2369243/0743a2c3-6386-4842-993c-8c23893c80e3)
