### PR TITLE
feat: implement debug mode switch for colab

### DIFF
--- a/boa/integrations/jupyter/browser.py
+++ b/boa/integrations/jupyter/browser.py
@@ -98,7 +98,7 @@ class BrowserRPC(RPC):
     An RPC object that sends requests to the browser via Javascript.
     """
 
-    debug_mode = False
+    _debug_mode = False
 
     @property
     def identifier(self) -> str:
@@ -171,11 +171,11 @@ def _javascript_call(js_func: str, *args, timeout_message: str) -> Any:
     token = _generate_token()
     args_str = ", ".join(json.dumps(p) for p in chain([token], args))
     js_code = f"window._titanoboa.{js_func}({args_str});"
-    if BrowserRPC.debug_mode:
+    if BrowserRPC._debug_mode:
         logging.warning(f"Calling {js_func} with {args_str}")
 
     if colab_eval_js:
-        install_jupyter_javascript_triggers(BrowserRPC.debug_mode)
+        install_jupyter_javascript_triggers(BrowserRPC._debug_mode)
         result = colab_eval_js(js_code)
         return _parse_js_result(json.loads(result))
 

--- a/boa/integrations/jupyter/browser.py
+++ b/boa/integrations/jupyter/browser.py
@@ -98,6 +98,8 @@ class BrowserRPC(RPC):
     An RPC object that sends requests to the browser via Javascript.
     """
 
+    debug_mode = False
+
     @property
     def identifier(self) -> str:
         return type(self).__name__  # every instance does the same
@@ -169,10 +171,11 @@ def _javascript_call(js_func: str, *args, timeout_message: str) -> Any:
     token = _generate_token()
     args_str = ", ".join(json.dumps(p) for p in chain([token], args))
     js_code = f"window._titanoboa.{js_func}({args_str});"
-    logging.warning(f"Calling {js_func} with {args_str}")
+    if BrowserRPC.debug_mode:
+        logging.warning(f"Calling {js_func} with {args_str}")
 
     if colab_eval_js:
-        install_jupyter_javascript_triggers()
+        install_jupyter_javascript_triggers(BrowserRPC.debug_mode)
         result = colab_eval_js(js_code)
         return _parse_js_result(json.loads(result))
 

--- a/boa/integrations/jupyter/jupyter.js
+++ b/boa/integrations/jupyter/jupyter.js
@@ -11,8 +11,11 @@
         return ethereum.request({method, params});
     };
 
-    // When opening in lab view, the base path contains extra folders
-    const base = `$$JUPYTERHUB_SERVICE_PREFIX`;  // gets replaced by the JupyterLab extension
+    // the following vars get replaced by the backend
+    const config = {
+        base: `$$JUPYTERHUB_SERVICE_PREFIX`,  // in lab view, base path is deeper
+        debug: $$BOA_DEBUG_MODE,
+    };
 
     /** Stringify data, converting big ints to strings */
     const stringify = (data) => JSON.stringify(data, (_, v) => (typeof v === 'bigint' ? v.toString() : v));
@@ -36,7 +39,7 @@
     async function callbackAPI(token, body) {
         const headers = {['X-XSRFToken']: getCookie('_xsrf')};
         const init = {method: 'POST', body, headers};
-        const url = `${base}/titanoboa_jupyterlab/callback/${token}`;
+        const url = `${config.base}/titanoboa_jupyterlab/callback/${token}`;
         const response = await fetch(url, init);
         return response.text();
     }
@@ -106,7 +109,7 @@
         }
 
         const body = stringify(await parsePromise(func(...args)));
-        // console.log(`Boa: ${func.name}(${args.map(a => JSON.stringify(a)).join(',')}) = ${body};`);
+        config.debug && console.log(`Boa: ${func.name}(${args.map(a => JSON.stringify(a)).join(',')}) = ${body};`);
         if (colab) {
             return body;
         }

--- a/boa/integrations/jupyter/jupyter.js
+++ b/boa/integrations/jupyter/jupyter.js
@@ -106,7 +106,7 @@
         }
 
         const body = stringify(await parsePromise(func(...args)));
-        console.log(`Boa: ${func.name}(${args.map(a => JSON.stringify(a)).join(',')}) = ${body};`);
+        // console.log(`Boa: ${func.name}(${args.map(a => JSON.stringify(a)).join(',')}) = ${body};`);
         if (colab) {
             return body;
         }

--- a/boa/integrations/jupyter/utils.py
+++ b/boa/integrations/jupyter/utils.py
@@ -9,14 +9,13 @@ def install_jupyter_javascript_triggers(debug_mode=False):
     """Run the ethers and titanoboa_jupyterlab Javascript snippets in the browser."""
     cur_dir = dirname(realpath(__file__))
     with open(join(cur_dir, "jupyter.js")) as f:
-        jupyter_js = f.read()
+        js = f.read()
+
     prefix = os.getenv("JUPYTERHUB_SERVICE_PREFIX", "..")
-    js = Javascript(
-        jupyter_js.replace("$$JUPYTERHUB_SERVICE_PREFIX", prefix).replace(
-            "$$BOA_DEBUG_MODE", json.dumps(debug_mode)
-        )
-    )
-    display(js)
+    js = js.replace("$$JUPYTERHUB_SERVICE_PREFIX", prefix)
+    js = js.replace("$$BOA_DEBUG_MODE", json.dumps(debug_mode))
+
+    display(Javascript(js))
 
 
 def convert_frontend_dict(data):

--- a/boa/integrations/jupyter/utils.py
+++ b/boa/integrations/jupyter/utils.py
@@ -4,13 +4,15 @@ from os.path import dirname, join, realpath
 from IPython.display import Javascript, display
 
 
-def install_jupyter_javascript_triggers():
+def install_jupyter_javascript_triggers(debug_mode=False):
     """Run the ethers and titanoboa_jupyterlab Javascript snippets in the browser."""
     cur_dir = dirname(realpath(__file__))
     with open(join(cur_dir, "jupyter.js")) as f:
         jupyter_js = f.read()
     prefix = os.getenv("JUPYTERHUB_SERVICE_PREFIX", "..")
     js = jupyter_js.replace("$$JUPYTERHUB_SERVICE_PREFIX", prefix)
+    if debug_mode:
+        js = js.replace("// console", "console")
     display(Javascript(js))
 
 

--- a/boa/integrations/jupyter/utils.py
+++ b/boa/integrations/jupyter/utils.py
@@ -1,3 +1,4 @@
+import json
 import os
 from os.path import dirname, join, realpath
 
@@ -10,10 +11,12 @@ def install_jupyter_javascript_triggers(debug_mode=False):
     with open(join(cur_dir, "jupyter.js")) as f:
         jupyter_js = f.read()
     prefix = os.getenv("JUPYTERHUB_SERVICE_PREFIX", "..")
-    js = jupyter_js.replace("$$JUPYTERHUB_SERVICE_PREFIX", prefix)
-    if debug_mode:
-        js = js.replace("// console", "console")
-    display(Javascript(js))
+    js = Javascript(
+        jupyter_js.replace("$$JUPYTERHUB_SERVICE_PREFIX", prefix).replace(
+            "$$BOA_DEBUG_MODE", json.dumps(debug_mode)
+        )
+    )
+    display(js)
 
 
 def convert_frontend_dict(data):


### PR DESCRIPTION
### What I did
- Added a switch that allows the user to switch on debug logging in google colab

### How I did it
- User may change the `BrowserRPC.debug_mode` variable or via env `boa.env._rpc.debug_mode = True`

### How to verify it
- Browser should display all the communication between the wallet and boa

### Description for the changelog
- feat: implement debug mode switch for colab

### Cute Animal Picture
![image](https://github.com/vyperlang/titanoboa/assets/2369243/397e6642-4236-44f6-87d0-1cf4fcaff36d)
