### PR TITLE
fix: remove internal frames from stack trace

### DIFF
--- a/boa/util/exceptions.py
+++ b/boa/util/exceptions.py
@@ -9,9 +9,10 @@ def strip_internal_frames(exc, module_name=None):
     frame = traceback.tb_frame
 
     if module_name is None:
-        module_name = frame.f_globals["__name__"]
+        # use the parent module of the module where the exception was raised
+        module_name = frame.f_globals["__name__"].rsplit(".", 1)[0]
 
-    while frame.f_globals.get("__name__", None) == module_name:
+    while frame.f_globals.get("__name__", "").startswith(module_name):
         frame = frame.f_back
 
     # kwargs incompatible with pypy here

--- a/tests/unitary/test_reverts.py
+++ b/tests/unitary/test_reverts.py
@@ -117,6 +117,14 @@ def test_compiler_reason_does_not_stop_dev_reason(contract):
             contract.bar(3)
 
 
+def test_strip_internal_frames(contract):
+    # but only in assert statements. in other cases, stomp!
+    with pytest.raises(BoaError) as context:
+        contract.baz(2**256 - 1)
+
+    assert str(context.traceback[-1].path) == __file__
+
+
 @pytest.mark.parametrize(
     "type_,empty", [("DynArray[uint8, 8]", []), ("String[8]", ""), ("Bytes[8]", b"")]
 )


### PR DESCRIPTION
### What I did
- Properly remove all internal frames from the BoaError stack trace

### How I did it
- use the parent module of the module where the exception was raised (i.e. `boa.contracts`)
- filter lines that occur in any sub-module (e.g. `boa.contracts.vyper_contract`)

### How to verify it
- Test is included

### Description for the changelog
- Fix stack trace containing internal frames

### Cute Animal Picture
![image](https://github.com/vyperlang/titanoboa/assets/2369243/ff0a6342-cb36-46a7-a58f-5045b85c60fa)
