### PR TITLE
fix[colab]: add optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ dependencies = [
 [project.optional-dependencies]
 forking-recommended = ["ujson"]
 
+# colab has antient ipykernel which causes bugs with decimals: https://github.com/jupyter/notebook/issues/5260
+colab = ["ipykernel>=6.29.4"]
+
 [build-system]
 requires = ["setuptools", "wheel"]
 

--- a/tests/unitary/jupyter/test_browser.py
+++ b/tests/unitary/jupyter/test_browser.py
@@ -202,6 +202,7 @@ def dummy() -> bool:
     mock_callback("eth_gasPrice", "0x0")
     mock_callback("eth_chainId", "0x1")
     mock_callback("eth_estimateGas", "0x0")
+    mock_callback("debug_traceCall", {})  # for prefetch state
     mock_callback("sendTransaction", {"hash": "0x123"})
     mock_callback(
         "waitForTransactionReceipt",


### PR DESCRIPTION
### What I did
- Create an optional dependency so users can easily use boa in colab

### How I did it
- Add a new optional dependency to ipykernel>6 when running in colab

### How to verify it
- Run `!pip install "titanoboa[colab] @ git+https://github.com/vyperlang/titanoboa.git@8293f1235"` in colab, `CurveStableSwapNGViews` should compile properly
- [Example notebook](https://colab.research.google.com/drive/1CxQ2URRf3AjRkKxd83u3fyJzzWAXlDpe?usp=sharing)

### Description for the changelog
- Create an optional dependency so users can easily use boa in colab

### Cute Animal Picture
![image](https://github.com/vyperlang/titanoboa/assets/2369243/0b175498-1841-47d6-be24-13a319892538)
