### PR TITLE
feat: abi method factory

### DIFF
--- a/boa/__init__.py
+++ b/boa/__init__.py
@@ -13,6 +13,7 @@ from boa.interpret import (
     loads,
     loads_abi,
     loads_partial,
+    loads_fn_sig,
 )
 from boa.network import NetworkEnv
 from boa.precompile import precompile

--- a/boa/contracts/abi/abi_contract.py
+++ b/boa/contracts/abi/abi_contract.py
@@ -4,7 +4,9 @@ from typing import Any, Optional, Union
 from warnings import warn
 
 from eth.abc import ComputationAPI
+from vyper.ast import parse_to_ast
 from vyper.semantics.analysis.base import FunctionVisibility, StateMutability
+from vyper.semantics.types.function import ContractFunctionT
 from vyper.utils import method_id
 
 from boa.contracts.base_evm_contract import (
@@ -351,6 +353,17 @@ class ABIContractFactory:
 
     @classmethod
     def from_abi_dict(cls, abi, name="<anonymous contract>", filename=None):
+        return cls(name, abi, filename)
+
+    @classmethod
+    def from_fn_sig(
+            cls, fn_sig, name="<anonymous contract function>", filename=None
+    ):
+        ast = parse_to_ast(fn_sig)
+        func_t = ContractFunctionT.from_FunctionDef(
+            ast.body[0], is_interface=True
+        )
+        abi = func_t.to_toplevel_abi_dict()
         return cls(name, abi, filename)
 
     def at(self, address: Address | str) -> ABIContract:

--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -146,6 +146,10 @@ def loads_abi(json_str: str, *args, name: str = None, **kwargs) -> ABIContractFa
     return ABIContractFactory.from_abi_dict(json.loads(json_str), name, *args, **kwargs)
 
 
+def loads_fn_sig(fn_str: str, *args, name: str = None, **kwargs) -> ABIContractFactory:
+    return ABIContractFactory.from_fn_sig(fn_str, name, *args, **kwargs)
+
+
 def loads_partial(
     source_code: str,
     name: str = None,

--- a/tests/unitary/contracts/fn_sig/test_fn_sig.py
+++ b/tests/unitary/contracts/fn_sig/test_fn_sig.py
@@ -3,3 +3,7 @@ import boa
 
 def test_load_fn_sig():
     pass
+    # fn = boa.loads_fn_sig("def balanceOf(a: address) -> uint256: view")
+    # boa.env.fork("https://eth.llamarpc.com")
+    # crv = fn.at("0xD533a949740bb3306d119CC777fa900bA034cd52")
+    # crv.balanceOf('0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2')

--- a/tests/unitary/contracts/fn_sig/test_fn_sig.py
+++ b/tests/unitary/contracts/fn_sig/test_fn_sig.py
@@ -1,0 +1,5 @@
+import boa
+
+
+def test_load_fn_sig():
+    pass


### PR DESCRIPTION
### What I did

Enables:

```
fn = boa.loads_fn_sig("def balanceOf(a: address) -> uint256: view")
crv = fn.at("0xD533a949740bb3306d119CC777fa900bA034cd52")
```

This way, I don't need to store a long abi file, or write a complicated json dict and let vyper handle it for me underneath.

### How I did it

Added method `from_fn_sig` to ABIContractFactory class, thus extending it's scope to beyond just providing a list of dict.

### How to verify it

Run test: https://github.com/bout3fiddy/titanoboa/blob/ac38a8b79a2467b8c68bbe42b38fd21e072a1caa/tests/integration/fork/test_abi_contract.py#L43

### Description for the changelog

Adds `boa.loads_fn_sig("def foo() -> uint256: view")` -> contract object.

### Cute Animal Picture

![image](https://github.com/user-attachments/assets/c8c58d55-343f-4eae-94a4-7bb7b01aeead)
