### PR TITLE
docs: correct network mode usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,10 +199,10 @@ Cast current deployed addresses to vyper contract
 
 ```python
 >>> import boa
->>> boa.env.set_network_env("<rpc server address>")
+>>> boa.set_network_env("<rpc server address>")
 >>> from eth_account import Account
 >>> # in a real codebase, always load private keys safely from an encrypted store!
->>> boa.env.add_account(Account(<a private key>))
+>>> boa.env.add_account(Account.from_key("<a private key>"))
 >>> c = boa.load("examples/ERC20.vy", "My Token", "TKN", 10**18, 10)
 >>> c.name()
     'My Token'


### PR DESCRIPTION
### What I did

Adjusted the documentation to reflect the proper way to use network mode

### How I did it

Tried what was in the readme, failed, looked through the titanoboa codebase, looked at the eth_account documentation, and then tested this

### How to verify it

Run that very example

### Description for the changelog

docs: correct network mode usage

### Cute Animal Picture

![image](https://github.com/user-attachments/assets/22dcc87f-e9c6-49f8-9b3e-3ac94e547df8)

