### PR TITLE
Use correct source code when error happens in library

### DIFF
--- a/boa/contracts/vyper/vyper_contract.py
+++ b/boa/contracts/vyper/vyper_contract.py
@@ -251,9 +251,7 @@ class ErrorDetail:
         reason = None
         if ast_source is not None:
             reason = DevReason.at_source_location(
-                contract.compiler_data.source_code,
-                ast_source.lineno,
-                ast_source.end_lineno,
+                ast_source.full_source_code, ast_source.lineno, ast_source.end_lineno
             )
         frame_detail = contract.debug_frame(computation)
 


### PR DESCRIPTION
### What I did
The incorrect source code was being sent to `DevReason.at_source_location`.
As a result, when the error happened in a library, the contract source code was being parsed, not the library code.
Generally, this meant that dev reasons were not working properly. However, if the contract happened to have invalid code at that line, boa would crash parsing that line. In the case encountered below, the contract line had a multiline string `"""` which by itself isn't valid code.

### How I did it
By using the ast source code, not the contract source code, when trying to get the dev reason.

### How to verify it
This should fix the parse errors encountered at the https://github.com/curvefi/autobribe repository, commit https://github.com/curvefi/autobribe/commit/efb752595a04b26b4e6209d589b4504c199cced4

### Cute Animal Picture
![image](https://github.com/user-attachments/assets/19074806-ce2a-4346-bb1f-cbe1b72feb21)

![Put a link to a cute animal picture inside the parenthesis-->]()