### PR TITLE
fix coverage for internal functions

### DIFF
--- a/boa/coverage.py
+++ b/boa/coverage.py
@@ -60,7 +60,10 @@ class TitanoboaTracer(coverage.plugin.FileTracer):
     def dynamic_source_filename(self, filename, frame):
         if not self._valid_frame(frame):
             return None
-        return frame.f_locals["filename"]
+        ret = frame.f_locals["filename"]
+        if ret is not None and not ret.endswith(".vy"):
+            return None
+        return ret
 
     def has_dynamic_source_filename(self):
         return True


### PR DESCRIPTION
the mock wrapper for internal functions would report a file of `"VyperContract"`. we can ignore these (as soon as they enter into the actual module, the pc traces should be correct anyway).

### What I did

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
