### PR TITLE
Add shortcut `state` property to env

### DIFF
--- a/boa/environment.py
+++ b/boa/environment.py
@@ -335,6 +335,10 @@ class Env:
     def _trace_cov(self, filename, node):
         pass
 
+    @property
+    def state(self):
+        return self.evm.state
+
     def get_code(self, address: _AddressType) -> bytes:
         return self.evm.get_code(Address(address))
 

--- a/tests/integration/fork/test_from_etherscan.py
+++ b/tests/integration/fork/test_from_etherscan.py
@@ -55,8 +55,8 @@ def test_prefetch_state(rpc_url, fresh_env, crvusd_contract):
         code=crvusd_contract._bytecode,
         data=crvusd_contract.burn.prepare_calldata(0),
     )
-    state = env.evm.vm.state
-    db = state._account_db
+
+    db = env.state._account_db
     db.try_prefetch_state(msg)
 
     # patch the RPC, so we make sure to use the cache


### PR DESCRIPTION
### What I did
It is currently quite cumbersome to get the evm state, e.g. the block number.
This PR allows users to call `boa.env.state.block_number` instead of `boa.env.evm.vm.state.block_number`.

### Cute Animal Picture
![image](https://github.com/user-attachments/assets/088975c1-895b-4777-8801-64d31ee5a6f6)
