### PR TITLE
fix: update expected Etherscan message

### DIFF
--- a/boa/explorer.py
+++ b/boa/explorer.py
@@ -28,7 +28,7 @@ def _fetch_etherscan(
         res = SESSION.get(uri, params=params)
         res.raise_for_status()
         data = res.json()
-        if data.get("result") != "Max rate limit reached":
+        if data.get("status") == "0" and "rate limit" in data.get("result", ""):
             break
         sleep(backoff_ms / 1000)
 

--- a/boa/explorer.py
+++ b/boa/explorer.py
@@ -28,7 +28,7 @@ def _fetch_etherscan(
         res = SESSION.get(uri, params=params)
         res.raise_for_status()
         data = res.json()
-        if data.get("status") == "0" and "rate limit" in data.get("result", ""):
+        if not (data.get("status") == "0" and "rate limit" in data.get("result", "")):
             break
         sleep(backoff_ms / 1000)
 


### PR DESCRIPTION
### What I did
- Updated the expected rate limit message
- Ethercan can return one of:
  - `{'status': '0', 'message': 'NOTOK', 'result': 'Max calls per sec rate limit reached (X/sec)'}` [example](https://github.com/vyperlang/titanoboa/actions/runs/10575632325/job/29299683807?pr=182#step:7:129)
  - `{'status': '0', 'message': 'NOTOK', 'result': 'Max rate limit reached'}` (existing code)
  - `{'status': '0', 'message': 'NOTOK', 'result': 'Max rate limit reached, please use API Key for higher rate limit'}` ([reference](https://docs.etherscan.io/support/common-error-messages))

### How I did it
- Checking the status of the response
- Checking the error message

### Cute Animal Picture
![image](https://github.com/user-attachments/assets/a65fae59-d8dd-4fe7-9d8b-85e588f6eeff)
