### PR TITLE
feat: deal cheatcode

### DIFF
--- a/boa/__init__.py
+++ b/boa/__init__.py
@@ -3,6 +3,7 @@ import sys
 
 from boa.contracts.base_evm_contract import BoaError
 from boa.contracts.vyper.vyper_contract import check_boa_error_matches
+from boa.dealer import deal
 from boa.debugger import BoaDebug
 from boa.environment import Env
 from boa.interpret import (

--- a/boa/dealer.py
+++ b/boa/dealer.py
@@ -1,5 +1,6 @@
 import boa
 from boa.util.abi import Address
+from boa.contracts.base_evm_contract import _BaseEVMContract
 
 SLOAD_OPCODE = 0x54
 
@@ -17,8 +18,7 @@ class SloadTracer:
         self.trace.append(slot)
 
 
-# TODO what's the correct type annotation for token (not only VyperContract)
-def deal(token, amount: int, receiver: Address):
+def deal(token: _BaseEVMContract, amount: int, receiver: Address):
     # we need to trace all sloads to find the
     # slot containing the balance of the target
     sload_tracer = SloadTracer(

--- a/boa/dealer.py
+++ b/boa/dealer.py
@@ -1,5 +1,4 @@
 import boa
-from boa import BoaError
 from boa.util.abi import Address
 
 SLOAD_OPCODE = 0x54
@@ -62,7 +61,8 @@ def deal(token, amount: int, receiver: Address):
 
     if target_slot is None:
         raise ValueError(
-            "Could not find the target slot, this is expected if the token packs storage slots or computes the balance on the fly"
+            "Could not find the target slot, this is expected if the token"
+            " packs storage slots or computes the balance on the fly"
         )
 
     boa.env.set_storage(token.address, target_slot, amount)

--- a/boa/dealer.py
+++ b/boa/dealer.py
@@ -1,6 +1,5 @@
 import boa
 from boa.util.abi import Address
-from boa.contracts.base_evm_contract import _BaseEVMContract
 
 SLOAD_OPCODE = 0x54
 
@@ -18,7 +17,8 @@ class SloadTracer:
         self.trace.append(slot)
 
 
-def deal(token: _BaseEVMContract, amount: int, receiver: Address):
+# TODO what's the correct type annotation for token (not only VyperContract)
+def deal(token, amount: int, receiver: Address):
     # we need to trace all sloads to find the
     # slot containing the balance of the target
     sload_tracer = SloadTracer(

--- a/boa/dealer.py
+++ b/boa/dealer.py
@@ -83,7 +83,7 @@ def _update_storage_slot(contract, fn_name, mk_new_value: Any, sload_tracer, arg
         raise ValueError(msg)
 
 
-def deal(token, amount: int, receiver: Address):
+def deal(token, amount: int, receiver: Address, adjust_supply: bool = True):
     """
     Mints `amount` of tokens to `receiver` and adjusts the total supply if `adjust_supply` is True.
     Inspired by https://github.com/foundry-rs/forge-std/blob/07263d193d/src/StdCheats.sol#L728
@@ -91,5 +91,6 @@ def deal(token, amount: int, receiver: Address):
     new_balance = lambda balance: balance + amount  # noqa: E731
     update_storage_slot(token, "balanceOf", new_balance, (receiver,))
 
-    new_supply = lambda totalSupply: totalSupply + amount  # noqa: E731
-    update_storage_slot(token, "totalSupply", new_supply, ())
+    if adjust_supply:
+        new_supply = lambda totalSupply: totalSupply + amount  # noqa: E731
+        update_storage_slot(token, "totalSupply", new_supply, ())

--- a/boa/dealer.py
+++ b/boa/dealer.py
@@ -1,0 +1,62 @@
+import boa
+from boa import BoaError
+from boa.util.abi import Address
+
+SLOAD_OPCODE = 0x54
+
+
+class SloadTracer:
+    def __init__(self, super_fn):
+        self.super_fn = super_fn
+        self.trace = []
+
+    def __call__(self, computation):
+        # TODO find a way to peak instead of pop/repush
+        slot = computation.stack_pop1_int()
+        computation.stack_push_int(slot)
+        self.super_fn(computation)
+        self.trace.append(slot)
+
+
+# TODO what's the correct type annotation for token (not only VyperContract)
+def deal(token, amount: int, receiver: Address):
+    # we need to trace all sloads to find the
+    # slot containing the balance of the target
+    sload_tracer = SloadTracer(
+        boa.env.evm.vm.state.computation_class.opcodes[SLOAD_OPCODE]
+    )
+    boa.patch_opcode(SLOAD_OPCODE, sload_tracer)
+
+    # since we have patched sload opcode,
+    # we can now trace the slot that contains
+    # the balance of the receiver.
+    # TODO handle custom signatures (i.e. `scaledBalanceOf`) for aTokens
+    try:
+        target_balance = token.balanceOf(receiver)
+    except BoaError:
+        raise ValueError("Invalid token contract, are you sure it's an ERC20?")
+
+    # we iteratively look for the slot that contains
+    # the balance of the receiver among all the slots accessed
+    # during the `balanceOf` call.
+
+    # This approach works on any memory layout as long as:
+    # 1. the balance is stored in a single unpacked slot.
+    # 2. the balance is not computed on the fly.
+    target_slot = None
+    for slot in sload_tracer.trace:
+        slot_value = boa.env.get_storage(token.address, slot)
+
+        # TODO handle balanceOf value collision with other storage slots
+        # containing the same value (very common if balance is 0)
+        if slot_value == target_balance:
+            target_slot = slot
+            break
+
+    assert target_slot is not None
+
+    boa.env.set_storage(token.address, target_slot, amount)
+
+    assert token.balanceOf(receiver) == amount
+
+    # TODO unpatch opcode

--- a/boa/dealer.py
+++ b/boa/dealer.py
@@ -95,6 +95,10 @@ def deal(token, receiver: Address, amount: int, adjust_supply: bool = True):
     Inspired by https://github.com/foundry-rs/forge-std/blob/07263d193d/src/StdCheats.sol#L728
     """
     update_balance = lambda _: amount  # noqa: E731
+    # we could handle "exotic" tokens if we accepted an additional argument, "expect_amount"
+    # so that user with low-level knowledge of how the token works can call deal() with the
+    # exact value of the storage slot and instead of checking `balanceOf` returns `amount`,
+    # we check that balanceOf returns `expect_amount`.
     old_balance = update_storage_slot(token, "balanceOf", update_balance, (receiver,))
 
     if adjust_supply:

--- a/tests/unitary/test_deal.py
+++ b/tests/unitary/test_deal.py
@@ -19,20 +19,6 @@ def test_simple_mapping_zero_balance():
     assert contract.totalSupply() == 100
 
 
-def test_simple_mapping_no_supply_adjustment():
-    source = """
-    balanceOf: public(HashMap[address, uint256])
-    totalSupply: public(uint256)
-    """
-
-    contract = boa.loads(source)
-
-    boa.deal(contract, 100, receiver := boa.env.generate_address(), adjust_supply=False)
-
-    assert contract.balanceOf(receiver) == 100
-    assert contract.totalSupply() == 0
-
-
 def test_simple_mapping_non_zero_balance():
     source = """
     balanceOf: public(HashMap[address, uint256])
@@ -50,8 +36,8 @@ def test_simple_mapping_non_zero_balance():
 
     boa.deal(contract, 100, receiver)
 
-    assert contract.balanceOf(receiver) == 100
-    assert contract.totalSupply() == 100
+    assert contract.balanceOf(receiver) == 220
+    assert contract.totalSupply() == 220
 
 
 def test_multiple_sloads_same_value():

--- a/tests/unitary/test_deal.py
+++ b/tests/unitary/test_deal.py
@@ -4,28 +4,52 @@ import boa
 
 
 def test_simple_mapping_zero_balance():
-    source = "balanceOf: public(HashMap[address, uint256])"
+    source = """
+    balanceOf: public(HashMap[address, uint256])
+    totalSupply: public(uint256)
+    """
 
     contract = boa.loads(source)
 
     boa.deal(contract, 100, receiver := boa.env.generate_address())
 
     assert contract.balanceOf(receiver) == 100
+    assert contract.totalSupply() == 100
+
+
+def test_simple_mapping_no_supply_adjustment():
+    source = """
+    balanceOf: public(HashMap[address, uint256])
+    totalSupply: public(uint256)
+    """
+
+    contract = boa.loads(source)
+
+    boa.deal(contract, 100, receiver := boa.env.generate_address(), adjust_supply=False)
+
+    assert contract.balanceOf(receiver) == 100
+    assert contract.totalSupply() == 0
 
 
 def test_simple_mapping_non_zero_balance():
-    source = "balanceOf: public(HashMap[address, uint256])"
-
+    source = """
+    balanceOf: public(HashMap[address, uint256])
+    totalSupply: public(uint256)
+    """
     contract = boa.loads(source)
 
     receiver = boa.env.generate_address()
 
     contract.eval(f"self.balanceOf[{receiver}] = 120")
+    contract.eval("self.totalSupply = 120")
+
     assert contract.balanceOf(receiver) == 120
+    assert contract.totalSupply() == 120
 
     boa.deal(contract, 100, receiver)
 
     assert contract.balanceOf(receiver) == 100
+    assert contract.totalSupply() == 100
 
 
 def test_multiple_sloads_same_value():
@@ -38,6 +62,7 @@ def test_multiple_sloads_same_value():
     def balanceOf(receiver: address) -> uint256:
         foobar: uint256 = self.bar + self.foo
         return self.foo
+    totalSupply: public(uint256)
     """
 
     contract = boa.loads(source)
@@ -45,12 +70,14 @@ def test_multiple_sloads_same_value():
     boa.deal(contract, 100, receiver := boa.env.generate_address())
 
     assert contract.balanceOf(receiver) == 100
+    assert contract.totalSupply() == 100
 
 
 def test_vvm_contract():
     source = """
     # pragma version 0.3.10
     balanceOf: public(HashMap[address, uint256])
+    totalSupply: public(uint256)
     """
 
     contract = boa.loads(source)
@@ -70,16 +97,51 @@ def test_deal_failure_non_erc20():
     contract = boa.loads(source)
 
     with pytest.raises(
-        ValueError, match="Invalid token contract, are you sure it's an ERC20?"
+        ValueError, match="Invalid erc20 contract, function balanceOf not found"
     ):
         boa.deal(contract, 100, boa.env.generate_address())
 
 
-def test_deal_failure_exotic_token():
+def test_deal_failure_non_erc20_totalSupply():
+    source = """
+    foo: public(uint256)
+    balanceOf: public(HashMap[address, uint256])
+    """
+
+    contract = boa.loads(source)
+
+    with pytest.raises(
+        ValueError, match="Invalid erc20 contract, function totalSupply not found"
+    ):
+        boa.deal(contract, 100, boa.env.generate_address())
+
+
+def test_deal_failure_exotic_token_balanceOf():
     code = """
     @external
     @view
     def balanceOf(receiver: address) -> uint256:
+        return 100
+
+    totalSupply: public(uint256)
+    """
+
+    contract = boa.loads(code)
+
+    with pytest.raises(
+        ValueError,
+        match="Could not find the target slot for balanceOf, this is expected if"
+        " the token packs storage slots or computes the value on the fly",
+    ):
+        boa.deal(contract, 100, boa.env.generate_address())
+
+
+def test_deal_failure_exotic_token_totalSupply():
+    code = """
+    balanceOf: public(HashMap[address, uint256])
+    @external
+    @view
+    def totalSupply() -> uint256:
         return 100
     """
 
@@ -87,7 +149,7 @@ def test_deal_failure_exotic_token():
 
     with pytest.raises(
         ValueError,
-        match="Could not find the target slot, this is expected if the token "
-        "packs storage slots or computes the balance on the fly",
+        match="Could not find the target slot for totalSupply, this is expected if"
+        " the token packs storage slots or computes the value on the fly",
     ):
         boa.deal(contract, 100, boa.env.generate_address())

--- a/tests/unitary/test_deal.py
+++ b/tests/unitary/test_deal.py
@@ -139,7 +139,7 @@ def test_deal_failure_exotic_token_balanceOf():
         match="Could not find the target slot for balanceOf, this is expected if"
         " the token packs storage slots or computes the value on the fly",
     ):
-        boa.deal(contract, boa.env.generate_address(), 100)
+        boa.deal(contract, boa.env.generate_address(), 101)
 
 
 def test_deal_failure_exotic_token_totalSupply():
@@ -158,4 +158,4 @@ def test_deal_failure_exotic_token_totalSupply():
         match="Could not find the target slot for totalSupply, this is expected if"
         " the token packs storage slots or computes the value on the fly",
     ):
-        boa.deal(contract, boa.env.generate_address(), 100)
+        boa.deal(contract, boa.env.generate_address(), 101)

--- a/tests/unitary/test_deal.py
+++ b/tests/unitary/test_deal.py
@@ -87,7 +87,7 @@ def test_deal_failure_exotic_token():
 
     with pytest.raises(
         ValueError,
-        match="Could not find the target slot, this is expected if the token"
+        match="Could not find the target slot, this is expected if the token "
         "packs storage slots or computes the balance on the fly",
     ):
         boa.deal(contract, 100, boa.env.generate_address())

--- a/tests/unitary/test_deal.py
+++ b/tests/unitary/test_deal.py
@@ -1,0 +1,85 @@
+import pytest
+
+import boa
+
+
+def test_simple_mapping_zero_balance():
+    source = "balanceOf: public(HashMap[address, uint256])"
+
+    contract = boa.loads(source)
+
+    boa.deal(contract, 100, receiver := boa.env.generate_address())
+
+    assert contract.balanceOf(receiver) == 100
+
+
+def test_simple_mapping_non_zero_balance():
+    source = "balanceOf: public(HashMap[address, uint256])"
+
+    contract = boa.loads(source)
+
+    receiver = boa.env.generate_address()
+
+    contract.eval(f"self.balanceOf[{receiver}] = 120")
+    assert contract.balanceOf(receiver) == 120
+
+    boa.deal(contract, 100, receiver)
+
+    assert contract.balanceOf(receiver) == 100
+
+
+def test_multiple_sloads_same_value():
+    source = """
+    foo: public(uint256)
+    bar: public(uint256)
+    
+    @view
+    @external
+    def balanceOf(receiver: address) -> uint256:
+        foobar: uint256 = self.bar + self.foo
+        return self.foo
+    """
+
+    contract = boa.loads(source)
+
+    boa.deal(contract, 100, receiver := boa.env.generate_address())
+
+    assert contract.balanceOf(receiver) == 100
+
+def test_vvm_contract():
+    source = """
+    # pragma version 0.3.10
+    balanceOf: public(HashMap[address, uint256])
+    """
+
+    contract = boa.loads(source)
+
+    print(type(contract))
+
+    boa.deal(contract, 100, receiver := boa.env.generate_address())
+
+    assert contract.balanceOf(receiver) == 100
+
+
+def test_deal_failure_non_erc20():
+    source = """
+    foo: public(uint256)
+    """
+
+    contract = boa.loads(source)
+
+    with pytest.raises(ValueError, match="Invalid token contract, are you sure it's an ERC20?"):
+        boa.deal(contract, 100, receiver := boa.env.generate_address())
+
+def test_deal_failure_exotic_token():
+    code = """
+    @external
+    @view
+    def balanceOf(receiver: address) -> uint256:
+        return 100
+    """
+
+    contract = boa.loads(code)
+
+    with pytest.raises(ValueError, match="Could not find the target slot, this is expected if the token packs storage slots or computes the balance on the fly"):
+        boa.deal(contract, 100, receiver := boa.env.generate_address())

--- a/tests/unitary/test_deal.py
+++ b/tests/unitary/test_deal.py
@@ -32,7 +32,7 @@ def test_multiple_sloads_same_value():
     source = """
     foo: public(uint256)
     bar: public(uint256)
-    
+
     @view
     @external
     def balanceOf(receiver: address) -> uint256:
@@ -45,6 +45,7 @@ def test_multiple_sloads_same_value():
     boa.deal(contract, 100, receiver := boa.env.generate_address())
 
     assert contract.balanceOf(receiver) == 100
+
 
 def test_vvm_contract():
     source = """
@@ -68,8 +69,11 @@ def test_deal_failure_non_erc20():
 
     contract = boa.loads(source)
 
-    with pytest.raises(ValueError, match="Invalid token contract, are you sure it's an ERC20?"):
-        boa.deal(contract, 100, receiver := boa.env.generate_address())
+    with pytest.raises(
+        ValueError, match="Invalid token contract, are you sure it's an ERC20?"
+    ):
+        boa.deal(contract, 100, boa.env.generate_address())
+
 
 def test_deal_failure_exotic_token():
     code = """
@@ -81,5 +85,9 @@ def test_deal_failure_exotic_token():
 
     contract = boa.loads(code)
 
-    with pytest.raises(ValueError, match="Could not find the target slot, this is expected if the token packs storage slots or computes the balance on the fly"):
-        boa.deal(contract, 100, receiver := boa.env.generate_address())
+    with pytest.raises(
+        ValueError,
+        match="Could not find the target slot, this is expected if the token"
+        "packs storage slots or computes the balance on the fly",
+    ):
+        boa.deal(contract, 100, boa.env.generate_address())

--- a/tests/unitary/test_deal.py
+++ b/tests/unitary/test_deal.py
@@ -19,6 +19,20 @@ def test_simple_mapping_zero_balance():
     assert contract.totalSupply() == 100
 
 
+def test_simple_mapping_no_supply_adjustment():
+    source = """
+    balanceOf: public(HashMap[address, uint256])
+    totalSupply: public(uint256)
+    """
+
+    contract = boa.loads(source)
+
+    boa.deal(contract, 100, receiver := boa.env.generate_address(), adjust_supply=False)
+
+    assert contract.balanceOf(receiver) == 100
+    assert contract.totalSupply() == 0
+
+
 def test_simple_mapping_non_zero_balance():
     source = """
     balanceOf: public(HashMap[address, uint256])

--- a/tests/unitary/test_deal.py
+++ b/tests/unitary/test_deal.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 import boa
@@ -97,7 +99,7 @@ def test_deal_failure_non_erc20():
     contract = boa.loads(source)
 
     with pytest.raises(
-        ValueError, match="Invalid erc20 contract, function balanceOf not found"
+        ValueError, match=re.escape(f"Function balanceOf not found in {contract}")
     ):
         boa.deal(contract, 100, boa.env.generate_address())
 
@@ -111,7 +113,7 @@ def test_deal_failure_non_erc20_totalSupply():
     contract = boa.loads(source)
 
     with pytest.raises(
-        ValueError, match="Invalid erc20 contract, function totalSupply not found"
+        ValueError, match=re.escape(f"Function totalSupply not found in {contract}")
     ):
         boa.deal(contract, 100, boa.env.generate_address())
 

--- a/tests/unitary/test_deal.py
+++ b/tests/unitary/test_deal.py
@@ -95,7 +95,7 @@ def test_vvm_contract(receiver):
     assert contract.balanceOf(receiver) == 100
 
 
-def test_deal_failure_non_erc20():
+def test_deal_failure_non_erc20(receiver):
     source = """
     foo: public(uint256)
     """
@@ -105,10 +105,10 @@ def test_deal_failure_non_erc20():
     with pytest.raises(
         ValueError, match=re.escape(f"Function balanceOf not found in {contract}")
     ):
-        boa.deal(contract, boa.env.generate_address(), 100)
+        boa.deal(contract, receiver, 100)
 
 
-def test_deal_failure_non_erc20_totalSupply():
+def test_deal_failure_non_erc20_totalSupply(receiver):
     source = """
     foo: public(uint256)
     balanceOf: public(HashMap[address, uint256])
@@ -119,10 +119,10 @@ def test_deal_failure_non_erc20_totalSupply():
     with pytest.raises(
         ValueError, match=re.escape(f"Function totalSupply not found in {contract}")
     ):
-        boa.deal(contract, boa.env.generate_address(), 100)
+        boa.deal(contract, receiver, 100)
 
 
-def test_deal_failure_exotic_token_balanceOf():
+def test_deal_failure_exotic_token_balanceOf(receiver):
     code = """
     @external
     @view
@@ -139,10 +139,10 @@ def test_deal_failure_exotic_token_balanceOf():
         match="Could not find the target slot for balanceOf, this is expected if"
         " the token packs storage slots or computes the value on the fly",
     ):
-        boa.deal(contract, boa.env.generate_address(), 101)
+        boa.deal(contract, receiver, 101)
 
 
-def test_deal_failure_exotic_token_totalSupply():
+def test_deal_failure_exotic_token_totalSupply(receiver):
     code = """
     balanceOf: public(HashMap[address, uint256])
     @external
@@ -158,4 +158,4 @@ def test_deal_failure_exotic_token_totalSupply():
         match="Could not find the target slot for totalSupply, this is expected if"
         " the token packs storage slots or computes the value on the fly",
     ):
-        boa.deal(contract, boa.env.generate_address(), 101)
+        boa.deal(contract, receiver, 101)


### PR DESCRIPTION
### What I did
Added a way to manipulate the most common implementations of ERC20 tokens balance.

### How I did it
This code traces SLOAD operations to find the storage slot containing an ERC20 token's balance for a given address. It patches the SLOAD opcode, records accessed slots during a balanceOf call, then identifies the correct slot by comparing values.

### How to verify it
Unit tests

### Cute Animal Picture
![image](https://github.com/user-attachments/assets/424ace69-79cc-4a44-8352-d30c9b42dd2c)
