### PR TITLE
fix: handling of selfdestruct

### DIFF
--- a/boa/contracts/vyper/vyper_contract.py
+++ b/boa/contracts/vyper/vyper_contract.py
@@ -791,6 +791,10 @@ class VyperContract(_BaseVyperContract):
         if vyper_typ is None:
             return None
 
+        # selfdestruct
+        if len(computation.beneficiaries) > 0:
+            return None
+
         return_typ = calculate_type_for_external_return(vyper_typ)
         ret = abi_decode(return_typ.abi_type.selector_name(), computation.output)
 

--- a/tests/unitary/contracts/vyper/test_vyper_contract.py
+++ b/tests/unitary/contracts/vyper/test_vyper_contract.py
@@ -61,3 +61,14 @@ def __init__():
     self.point = [1, 2]
 """
     assert boa.loads(code)._storage.point.get() == [1, 2]
+
+
+def test_self_destruct():
+    code = """
+@external
+def foo() -> bool:
+    selfdestruct(msg.sender)
+    """
+    c = boa.loads(code)
+
+    c.foo()


### PR DESCRIPTION
in this case, is_error is not set, so marshal_to_python tries to decode non-existent return value. this inspects `computation.beneficiaries` to check if a selfdestruct happened.

credit @Leminkay for triage and diagnosis of the bug.

### What I did
fix #269 

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
