### PR TITLE
Try to use a public RPC for forked tests

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -49,12 +49,6 @@ jobs:
           pip install -r dev-requirements.txt
           pip install .[forking-recommended]
 
-      - name: Run Fork Mode Tests
-        run: pytest -n auto tests/integration/fork/
-        env:
-          MAINNET_ENDPOINT: ${{ secrets.ALCHEMY_MAINNET_ENDPOINT }}
-          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
-
       - name: Run Sepolia Tests
         # disable xdist, otherwise they can contend for tx nonce
         run: pytest -n 0 tests/integration/network/sepolia/

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -63,6 +63,12 @@ jobs:
           pip install -r dev-requirements.txt
           pip install .
 
+      - name: Run Fork Mode Tests
+        run: pytest -n auto tests/integration/fork
+        env:
+          MAINNET_ENDPOINT: ${{ secrets.ALCHEMY_MAINNET_ENDPOINT }}
+          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 

--- a/boa/util/retry.py
+++ b/boa/util/retry.py
@@ -1,0 +1,52 @@
+import time
+
+
+class Retry(ValueError):
+    ...
+
+
+def retry_fn(
+    fn, exception=Retry, num_retries=10, backoff_ms=400, exponential_factor=1.1
+):
+    """
+    Retry a function call (no arguments, use retry() decorator or lambda otherwise).
+    It supports exponential backoff and a maximum number of retries.
+    :param fn: The function to retry.
+    :param exception: The exception to catch.
+    :param num_retries: The number of times to retry.
+    :param backoff_ms: The backoff time in milliseconds.
+    :param exponential_factor: The exponential factor to use.
+    :return: The result of the function call.
+    """
+    for i in range(num_retries):
+        try:
+            return fn()
+        except exception as e:
+            if i + 1 == num_retries:
+                raise e
+            time.sleep(backoff_ms * (exponential_factor**i))
+
+
+def retry(*args, **kwargs):
+    """
+    A decorator for retrying a function call with support for arguments.
+    :param args: The arguments to pass to retry.
+    :param kwargs: The keyword arguments to pass to retry.
+    :return: A decorator that retries the function call.
+    """
+
+    def decorator(fn):
+        """:return: A new function that is decorated with retry."""
+
+        def wrapper(*fn_args, **fn_kwargs):
+            """:return: The result of retrying the function call."""
+
+            def decorated():
+                """:return: The result of the function call which may be retried."""
+                return fn(*fn_args, **fn_kwargs)
+
+            return retry_fn(decorated, *args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/tests/integration/fork/conftest.py
+++ b/tests/integration/fork/conftest.py
@@ -7,7 +7,7 @@ import boa
 
 @pytest.fixture(scope="module")
 def rpc_url():
-    return os.environ.get("MAINNET_ENDPOINT") or "http://localhost:8545"
+    return os.getenv("MAINNET_ENDPOINT", "https://eth.drpc.org")
 
 
 # run all tests with this forked environment


### PR DESCRIPTION
### What I did
- Check whether it's feasible to run tests in a public RPC
- Refactor the retry mechanism into a decorator
  - Use that for etherscan and API rate limited requests

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![image](https://github.com/user-attachments/assets/6d0a99ea-0dc4-4988-bd74-e2ac3435a854)
