### PR TITLE
feat: added warning suppression for if you don't care that a contract has no bytecode

### DIFF
--- a/boa/contracts/abi/abi_contract.py
+++ b/boa/contracts/abi/abi_contract.py
@@ -376,7 +376,7 @@ class ABIContractFactory:
             self.functions,
             address,
             self.filename,
-            suppress_warning=suppress_warning
+            suppress_warning=suppress_warning,
         )
 
         contract.env.register_contract(address, contract)

--- a/boa/contracts/abi/abi_contract.py
+++ b/boa/contracts/abi/abi_contract.py
@@ -365,13 +365,18 @@ class ABIContractFactory:
     def from_abi_dict(cls, abi, name="<anonymous contract>", filename=None):
         return cls(name, abi, filename)
 
-    def at(self, address: Address | str, suppress_warning: bool= False) -> ABIContract:
+    def at(self, address: Address | str, suppress_warning: bool = False) -> ABIContract:
         """
         Create an ABI contract object for a deployed contract at `address`.
         """
         address = Address(address)
         contract = ABIContract(
-            self._name, self._abi, self.functions, address, self.filename, suppress_warning=suppress_warning
+            self._name,
+            self._abi,
+            self.functions,
+            address,
+            self.filename,
+            suppress_warning=suppress_warning
         )
 
         contract.env.register_contract(address, contract)

--- a/boa/contracts/abi/abi_contract.py
+++ b/boa/contracts/abi/abi_contract.py
@@ -236,6 +236,7 @@ class ABIContract(_BaseEVMContract):
         functions: list[ABIFunction],
         address: Address,
         filename: Optional[str] = None,
+        suppress_warning: bool = False,
         env=None,
     ):
         super().__init__(name, env, filename=filename, address=address)
@@ -243,7 +244,7 @@ class ABIContract(_BaseEVMContract):
         self._functions = functions
 
         self._bytecode = self.env.get_code(address)
-        if not self._bytecode:
+        if not self._bytecode and not suppress_warning:
             warn(
                 f"Requested {self} but there is no bytecode at that address!",
                 stacklevel=2,
@@ -364,13 +365,13 @@ class ABIContractFactory:
     def from_abi_dict(cls, abi, name="<anonymous contract>", filename=None):
         return cls(name, abi, filename)
 
-    def at(self, address: Address | str) -> ABIContract:
+    def at(self, address: Address | str, suppress_warning: bool= False) -> ABIContract:
         """
         Create an ABI contract object for a deployed contract at `address`.
         """
         address = Address(address)
         contract = ABIContract(
-            self._name, self._abi, self.functions, address, self.filename
+            self._name, self._abi, self.functions, address, self.filename, suppress_warning=suppress_warning
         )
 
         contract.env.register_contract(address, contract)

--- a/tests/unitary/contracts/abi/test_abi.py
+++ b/tests/unitary/contracts/abi/test_abi.py
@@ -6,8 +6,9 @@ from eth.constants import ZERO_ADDRESS
 
 import boa
 from boa import BoaError
-from boa.contracts.abi.abi_contract import ABIContractFactory, ABIFunction
+from boa.contracts.abi.abi_contract import ABIContractFactory, ABIFunction, ABIContract
 from boa.util.abi import Address
+import warnings
 
 
 def load_via_abi(code, name="test contract"):
@@ -158,6 +159,18 @@ def test() -> uint256:
     with pytest.raises(BoaError) as e:
         abi_contract.test()
     assert "no bytecode at this address!" in str(e.value)
+
+
+def test_bad_address_suppressed():
+    code = """
+@external
+def test() -> uint256:
+    return 0
+"""
+    abi_contract, _ = load_via_abi(code)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        abi_contract = abi_contract.deployer.at(ZERO_ADDRESS, suppress_warning=True)
 
 
 def test_abi_reverts():

--- a/tests/unitary/contracts/abi/test_abi.py
+++ b/tests/unitary/contracts/abi/test_abi.py
@@ -6,7 +6,7 @@ from eth.constants import ZERO_ADDRESS
 
 import boa
 from boa import BoaError
-from boa.contracts.abi.abi_contract import ABIContractFactory, ABIFunction, ABIContract
+from boa.contracts.abi.abi_contract import ABIContractFactory, ABIFunction
 from boa.util.abi import Address
 import warnings
 

--- a/tests/unitary/contracts/abi/test_abi.py
+++ b/tests/unitary/contracts/abi/test_abi.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 
 import pytest
 import yaml
@@ -8,7 +9,6 @@ import boa
 from boa import BoaError
 from boa.contracts.abi.abi_contract import ABIContractFactory, ABIFunction
 from boa.util.abi import Address
-import warnings
 
 
 def load_via_abi(code, name="test contract"):


### PR DESCRIPTION
### What I did

I added a `suppress_warning: bool = False` keyword argument to:

1. `ABIContract::__init__`
2. `ABIContract::at`

The rationale for this is as such:

1. Using the `from_etherscan` command in `boa` without being on the same network as the `uri` will cause this warning to be thrown. So, we should have an option to suppress the warning if we choose a custom uri.
2. There are scenarios where we may want to assign an ABI to an address with empty code, for example in the case of using `CREATE2` to deploy a contract

It may make sense to set this flag to `true` when calling this function from `from_etherscan`

### How I did it

```diff
- def at(self, address: Address | str) -> ABIContract:
+ def at(self, address: Address | str, suppress_warning: bool= False) -> ABIContract:
```

### How to verify it

I added the following test:

```python
def test_bad_address_suppressed():
    code = """
@external
def test() -> uint256:
    return 0
"""
    abi_contract, _ = load_via_abi(code)
    with warnings.catch_warnings():
        warnings.simplefilter("error")
        abi_contract = abi_contract.deployer.at(ZERO_ADDRESS, suppress_warning=True)
```

The code:

```python
with warnings.catch_warnings():
        warnings.simplefilter("error
```

Will error if any warning is thrown, so this test passing means the warning is not being thrown.

```bash
pytest -k test_bad_address_suppressed
```

### Description for the changelog

- feat: enabled `ABIContract` objects created before bytecode assigned to ignore warnings flagged

### Cute Animal Picture

![image](https://github.com/user-attachments/assets/eba2c438-cc24-4d1f-9101-4e54c5e5c654)

