### PR TITLE
Fix for VVM with non-fixed version pragma

### DIFF
--- a/boa/contracts/vvm/vvm_contract.py
+++ b/boa/contracts/vvm/vvm_contract.py
@@ -1,20 +1,58 @@
 import re
 from functools import cached_property
 
+from vvm.utils.convert import to_vyper_version
 from boa.contracts.abi.abi_contract import ABIContractFactory, ABIFunction
 from boa.environment import Env
 
 # TODO: maybe this doesn't detect release candidates
-VERSION_RE = re.compile(r"\s*#\s*(pragma\s+version|@version)\s+(\d+\.\d+\.\d+)")
+VERSION_RE = re.compile(r"\s*#\s*(pragma\s+version|@version)\s+(\^|>=)?(\d+\.\d+\.\d+)")
 
 
 # TODO: maybe move this up to vvm?
-def _detect_version(source_code: str):
+# 1. Detects version from source file
+# 2. In case of ^ or >= and if vyper_version is provided, returns vyper_version is allowed
+def _detect_version(source_code: str, vyper_version: str = None) -> str:
     res = VERSION_RE.findall(source_code)
     if len(res) < 1:
         return None
     # TODO: handle len(res) > 1
-    return res[0][1]
+
+    # Exact version specified
+    if res[0][1] == "":
+        return res[0][2]
+    # Caret means we check if vyper_version is compatible
+    elif res[0][1] == "^":
+        if vyper_version:
+            min_version = to_vyper_version(res[0][2])
+            # Compute maximum version according to rules
+            min_nonallowed_version = to_vyper_version(
+                f"0.{min_version.minor+1}.0"
+                if min_version.major == 0
+                else f"{min_version.major+1}.0.0"
+            )
+            vy_version = to_vyper_version(vyper_version)
+            if min_version <= vy_version and vy_version < min_nonallowed_version:
+                return vyper_version
+            else:
+                # Else use minimum allowed version
+                return res[0][2]
+        else:
+            return res[0][2]
+    # Greater-Equal means we check if vyper_version is compatible
+    elif res[0][1] == ">=":
+        # If vyper_version is allowed by >=, use it
+        if vyper_version:
+            if to_vyper_version(vyper_version) >= to_vyper_version(res[0][2]):
+                return vyper_version
+            else:
+                # Else use minimum allowed version
+                return res[0][2]
+        else:
+            return res[0][2]
+    # Unknown Operand
+    else:
+        return None
 
 
 class VVMDeployer:

--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -213,7 +213,7 @@ def loads_partial(
     if dedent:
         source_code = textwrap.dedent(source_code)
 
-    version = _detect_version(source_code)
+    version = _detect_version(source_code, vyper_version=vyper.__version__)
     if version is not None and version != vyper.__version__:
         filename = str(filename)  # help mypy
         return _loads_partial_vvm(source_code, version, filename)

--- a/tests/unitary/contracts/vvm/test_vvm.py
+++ b/tests/unitary/contracts/vvm/test_vvm.py
@@ -1,4 +1,5 @@
 import boa
+from boa.contracts.vvm.vvm_contract import _detect_version
 
 mock_3_10_path = "tests/unitary/contracts/vvm/mock_3_10.vy"
 
@@ -37,3 +38,67 @@ def test_loads_vvm():
 
     assert contract.foo() == 42
     assert contract.bar() == 43
+
+
+def test_detect_version():
+    code_floating = """
+# pragma version ^0.3.9
+@external
+def foo() -> uint256:
+    x: uint256 = 1
+    return x + 7
+"""
+    assert _detect_version(code_floating) == "0.3.9"
+
+    code_ge = """
+# pragma version >=0.3.9
+@external
+def foo() -> uint256:
+    x: uint256 = 1
+    return x + 7
+"""
+    assert _detect_version(code_ge) == "0.3.9"
+
+    code_fixed = """
+# pragma version 0.3.9
+@external
+def foo() -> uint256:
+    x: uint256 = 1
+    return x + 7
+"""
+    assert _detect_version(code_fixed) == "0.3.9"
+
+
+def test_detect_version_with_vyper_version():
+    code_floating = """
+# pragma version ^0.3.9
+@external
+def foo() -> uint256:
+    x: uint256 = 1
+    return x + 7
+"""
+    assert _detect_version(code_floating, vyper_version="0.3.9") == "0.3.9"
+    assert _detect_version(code_floating, vyper_version="0.3.10") == "0.3.10"
+    assert _detect_version(code_floating, vyper_version="0.4.0") == "0.3.9"
+
+    code_ge = """
+# pragma version >=0.3.9
+@external
+def foo() -> uint256:
+    x: uint256 = 1
+    return x + 7
+"""
+    assert _detect_version(code_ge, vyper_version="0.3.9") == "0.3.9"
+    assert _detect_version(code_ge, vyper_version="0.3.10") == "0.3.10"
+    assert _detect_version(code_ge, vyper_version="0.4.0") == "0.4.0"
+
+    code_fixed = """
+# pragma version 0.3.9
+@external
+def foo() -> uint256:
+    x: uint256 = 1
+    return x + 7
+"""
+    assert _detect_version(code_fixed, vyper_version="0.3.9") == "0.3.9"
+    assert _detect_version(code_fixed, vyper_version="0.3.10") == "0.3.9"
+    assert _detect_version(code_fixed, vyper_version="0.4.0") == "0.3.9"


### PR DESCRIPTION
### What I did

There was the following problem with non-fixed pragmas (vyper_version = 0.4.0):
```
import boa
boa.load("examples/simple.vy")
```
Leads to error:
```
vyper.exceptions.VersionException: Version specification "~=0.3.9" is not compatible with compiler version "0.4.0"
```
simple.vy:
```
# pragma version ^0.3.9
@external
def foo() -> uint256:
    x: uint256 = 1
    return x + 7
```
That happens because `_detect_version` returns None in this case, so VVM is not used, but compilation also fails.

So I changed `_detect_version` so that it:
1. Parses the full pragma (including >= or ^)
2. Decides on the right version depending on the pragma and the optionally provided vyper_version
3. Returns the right version

### How I did it

- If a fixed version is specified: it is always returned
- If ^version is specified:
  - If the vyper_version is specified and allowed, the vyper_version is returned
  - Else, the minimum version is returned
- If >=version is specified:
  - If the vyper_version is specified and allowed, the vyper_version is returned
  - Else, the minimum version is returned
 

### How to verify it

See the new tests I added 

### Description for the changelog

Parse version pragma more precisely to use vvm if necessary

### Cute Animal Picture

![](https://i.pinimg.com/originals/e4/ce/db/e4cedb03bd1fda8d296b905852f3a3d5.jpg)
