### PR TITLE
fix: merge conflict issue in jupyter integration

### DIFF
--- a/boa/integrations/jupyter/jupyter.js
+++ b/boa/integrations/jupyter/jupyter.js
@@ -42,14 +42,6 @@
         return response.text();
     }
 
-    const loadSigner = async (address) => {
-        const accounts = await rpc('eth_requestAccounts');
-        return accounts.includes(address) ? address : accounts[0];
-    };
-
-    /** Sign a transaction via ethers */
-    const sendTransaction = async transaction => ({"hash": await rpc('eth_sendTransaction', [transaction])});
-
     /** Wait until the transaction is mined */
     const waitForTransactionReceipt = async (tx_hash, timeout, poll_latency) => {
         while (true) {
@@ -81,7 +73,7 @@
     const handleCallback = func => async (token, ...args) => {
         if (!colab) {
             // Check backend and whether cell was executed. In Colab, eval_js() doesn't replay.
-            const response = await fetch(`${base}/titanoboa_jupyterlab/callback/${token}`);
+            const response = await fetch(`${config.base}/titanoboa_jupyterlab/callback/${token}`);
             if (response.status === 404 && response.headers.get('Content-Type') === 'application/json') {
                 return; // the cell has already been executed
             }
@@ -108,8 +100,6 @@
 
     // expose functions to window, so they can be called from the BrowserSigner
     window._titanoboa = {
-        loadSigner: handleCallback(loadSigner),
-        sendTransaction: handleCallback(sendTransaction),
         waitForTransactionReceipt: handleCallback(waitForTransactionReceipt),
         rpc: handleCallback(rpc),
         multiRpc: handleCallback(multiRpc),


### PR DESCRIPTION
### What I did
- Fixed 2 issues that were raised by merge conflicts and incorrectly solved
  - The `config` object was introduced in https://github.com/vyperlang/titanoboa/commit/6c4524677381200054f502ccb4f53692238a5ff0, but commit [517e7df](https://github.com/vyperlang/titanoboa/commit/517e7df49140482e860c74d893e9cd0394913e42#diff-182fd90cef1fb2af67209a24706164d38020e4a61d6b696d3cc7ee1e99183d73R88) missed this
  - The functions `loadSigner` and `sendTransaction` were deleted in [9307ce90](https://github.com/vyperlang/titanoboa/pull/174/commits/9307ce90c8c5d7ad20502ea5e2be653bc9105c56#diff-182fd90cef1fb2af67209a24706164d38020e4a61d6b696d3cc7ee1e99183d73) but then mistakenly reintroduced in the merge commit [bbd1a6](https://github.com/vyperlang/titanoboa/pull/174/commits/bbd1a61425e7f7f6234c2a59fe6859e3a2065c53#diff-182fd90cef1fb2af67209a24706164d38020e4a61d6b696d3cc7ee1e99183d73)

### How to verify it
- Jupyter integration (outside colab) should work again

### Cute Animal Picture
![image](https://github.com/user-attachments/assets/bfee7ee1-792a-4632-9ed7-3c90e434688c)
