### PR TITLE
fix[verify]: check whether the contract is really verified

### DIFF
--- a/boa/verifiers.py
+++ b/boa/verifiers.py
@@ -104,7 +104,7 @@ class Blockscout:
         if response.status_code in self.retry_http_codes:
             return False
         response.raise_for_status()
-        return True
+        return response.json().get("is_verified", False)
 
 
 _verifier = Blockscout()


### PR DESCRIPTION
### What I did
@AlbertoCentonze tried to verfiy a contract with boa. The contract could be found in `/smart-contracts` API call, but misses the `is_verified` field. This PR should add a check to make sure the contract is actually verified.
I'm trying to contact Blockscout devs to check what's going on in this case, given the verification via UI worked fine.


### Cute Animal Picture
![image](https://github.com/user-attachments/assets/bcc11a40-cd42-424b-86b7-7b7795f2b5b2)
