### PR TITLE
feat: have set_env return a context manager

### DIFF
--- a/boa/__init__.py
+++ b/boa/__init__.py
@@ -37,25 +37,20 @@ env = Env.get_singleton()
 
 @contextlib.contextmanager
 def swap_env(new_env):
-    old_env = env
-    try:
-        set_env(new_env)
+    with set_env(new_env):
         yield
-    finally:
-        set_env(old_env)
 
 
 def set_env(new_env):
     global env
-    env = new_env
-
-    Env._singleton = new_env
-
-
-def _env_mgr(new_env):
-    global env
     get_env = lambda: env  # noqa: E731
-    return Open(get_env, set_env, new_env)
+
+    def setter(new):
+        global env
+        env = new
+        Env._singleton = new
+
+    return Open(get_env, setter, new_env)
 
 
 def fork(
@@ -69,7 +64,7 @@ def fork(
 
     new_env = Env()
     new_env.fork(url=url, block_identifier=block_identifier, deprecated=False, **kwargs)
-    return _env_mgr(new_env)
+    return set_env(new_env)
 
 
 def set_browser_env(address=None):
@@ -77,12 +72,12 @@ def set_browser_env(address=None):
     # import locally because jupyter is generally not installed
     from boa.integrations.jupyter import BrowserEnv
 
-    return _env_mgr(BrowserEnv(address))
+    return set_env(BrowserEnv(address))
 
 
 def set_network_env(url):
     """Set the environment to use a custom network URL"""
-    return _env_mgr(NetworkEnv.from_url(url))
+    return set_env(NetworkEnv.from_url(url))
 
 
 def set_etherscan(*args, **kwargs):

--- a/boa/__init__.py
+++ b/boa/__init__.py
@@ -41,16 +41,16 @@ def swap_env(new_env):
         yield
 
 
+def _set_env(new):
+    global env
+    env = new
+    Env._singleton = new
+
+
 def set_env(new_env):
     global env
     get_env = lambda: env  # noqa: E731
-
-    def setter(new):
-        global env
-        env = new
-        Env._singleton = new
-
-    return Open(get_env, setter, new_env)
+    return Open(get_env, _set_env, new_env)
 
 
 def fork(

--- a/tests/unitary/test_boa.py
+++ b/tests/unitary/test_boa.py
@@ -4,7 +4,7 @@ import boa
 def test_env_mgr_noctx():
     s = boa.env
     t = boa.Env()
-    boa._env_mgr(t)
+    boa.set_env(t)
     assert boa.env is not s
     assert boa.env is t
 
@@ -13,7 +13,7 @@ def test_env_mgr_with_ctx():
     s = boa.env
     t = boa.Env()
 
-    with boa._env_mgr(t):
+    with boa.set_env(t):
         assert boa.env is not s
         assert boa.env is t
 


### PR DESCRIPTION
### What I did
- Use the `Open` helper in `set_env`

### How I did it
- Refactor other methods to use `set_env` instead of `_env_mgr` as they became the same

### Cute Animal Picture
![image](https://github.com/user-attachments/assets/cb11679c-490a-48f0-8b2d-9f7fa23b83f0)
