### PR TITLE
feat: add filename to deployments db

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,12 @@ git commit -m 'your commit message'
 git push <your_forked_github>
 ```
 
+4. Run the linter
+
+```bash
+make lint
+```
+
 ## Running Tests
 
 Once you have your environment setup, you can run the tests to make sure everything is working as expected. You'll need to have your virtual environment activated to run the tests.

--- a/boa/deployments.py
+++ b/boa/deployments.py
@@ -116,12 +116,8 @@ class DeploymentsDB:
 
         # Migration for legacy DB without filename column
         if not self._filename_is_in_db():
-            try:
-                self.db.execute("ALTER TABLE deployments ADD COLUMN filename text;")
-                self.db.commit()
-            except sqlite3.Error as e:
-                self.db.rollback()
-                raise Exception(f"Failed to add 'filename' column: {e}")
+            self.db.execute("ALTER TABLE deployments ADD COLUMN filename text;")
+            self.db.commit()
 
     def __del__(self):
         self.db.close()

--- a/boa/deployments.py
+++ b/boa/deployments.py
@@ -115,6 +115,7 @@ class DeploymentsDB:
         self.db.execute(_CREATE_CMD)
 
         # Migration for legacy DB without filename column
+        # We can/should remove this after some time (all 4 users migrate)
         self._apply_filename_migration()
 
     def __del__(self):
@@ -138,7 +139,6 @@ class DeploymentsDB:
         if is_in_db:
             return
         self.db.execute("ALTER TABLE deployments ADD COLUMN filename text;")
-        self.db.commit()
 
     def _get_deployments_from_sql(self, sql_query: str, parameters=(), /):
         cur = self.db.execute(sql_query, parameters)

--- a/boa/network.py
+++ b/boa/network.py
@@ -403,6 +403,7 @@ class NetworkEnv(Env):
 
         if (deployments_db := get_deployments_db()) is not None:
             contract_name = getattr(contract, "contract_name", None)
+            filename = getattr(contract, "filename", None)
             try:
                 source_bundle = get_verification_bundle(contract)
             except Exception as e:
@@ -419,6 +420,7 @@ class NetworkEnv(Env):
             deployment_data = Deployment(
                 create_address,
                 contract_name,
+                filename,
                 self._rpc.name,
                 sender,
                 receipt["transactionHash"],

--- a/tests/integration/network/anvil/test_network_env.py
+++ b/tests/integration/network/anvil/test_network_env.py
@@ -153,5 +153,8 @@ def test_deployments_db_migration(temp_legacy_db_path):
     columns = [col[1] for col in cursor.fetchall()]
     assert "filename" not in columns
 
+    # This next line is what does the migration (added the filename column)
     db = DeploymentsDB(temp_legacy_db_path)
-    assert db._filename_is_in_db() is True
+    cursor = db.db.execute("PRAGMA table_info(deployments);")
+    columns = [col[1] for col in cursor.fetchall()]
+    assert "filename" in columns

--- a/tests/integration/network/anvil/test_network_env.py
+++ b/tests/integration/network/anvil/test_network_env.py
@@ -1,16 +1,16 @@
+import sqlite3
+import tempfile
+from pathlib import Path
+
 import pytest
 from hypothesis import given, settings
 
 import boa
 import boa.test.strategies as vy
-from boa.deployments import DeploymentsDB, set_deployments_db
+from boa.deployments import _CREATE_CMD, DeploymentsDB, set_deployments_db
 from boa.network import NetworkEnv
 from boa.rpc import to_bytes
 from boa.util.abi import Address
-import tempfile
-from pathlib import Path
-import sqlite3
-from boa.deployments import _CREATE_CMD
 
 code = """
 totalSupply: public(uint256)


### PR DESCRIPTION
### What I did

add a `filename` column to the database

### How I did it

```python
class DeploymentsDB:
    def __init__(self, path=":memory:"):
        if path != ":memory:":  # sqlite magic path
            path = Path(path)
            path.parent.mkdir(parents=True, exist_ok=True)

        # once 3.12 is min version, use autocommit=True
        self.db = sqlite3.connect(path)
        self.db.execute(_CREATE_CMD)

        # Migration for legacy DB without filename column
        if not self._filename_is_in_db():
            try:
                self.db.execute("ALTER TABLE deployments ADD COLUMN filename text;")
                self.db.commit()
            except sqlite3.Error as e:
                self.db.rollback()
                raise Exception(f"Failed to add 'filename' column: {e}")
```

### How to verify it

You can run the test I created:

```bash
pytest -k test_deployments_db_migration
```

### Description for the changelog

- feat: Added migration for databases without the filename column

### Cute Animal Picture

![image](https://github.com/user-attachments/assets/627c8fe6-cc7f-4382-ba01-1177b1002d90)

