### PR TITLE
docs: simplify commit instruction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,8 +67,7 @@ git checkout -b <branch_name>
 And start making your changes! Once you're done, you can commit your changes and push them to your forked repo.
 
 ```bash
-git add .
-git commit -m 'your commit message'
+git commit -a
 git push <your_forked_github>
 ```
 


### PR DESCRIPTION
prefer `git commit` without `-m` as it forces you to think about the commit message. `git add .` is also a bit dangerous since you can accidentally add files you did not mean to add. `git commit -a` rather only adds changes tracked files.

### What I did

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
