### PR TITLE
fix: add base path to loads_partial_vvm

### DIFF
--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -273,7 +273,9 @@ def load_partial(filename: str, compiler_args=None):
         )
 
 
-def _loads_partial_vvm(source_code: str, version: Version, filename: str, base_path=None):
+def _loads_partial_vvm(
+    source_code: str, version: Version, filename: str, base_path=None
+):
     global _disk_cache
 
     if base_path is None:
@@ -283,7 +285,9 @@ def _loads_partial_vvm(source_code: str, version: Version, filename: str, base_p
     vvm.install_vyper(version=version)
 
     def _compile():
-        compiled_src = vvm.compile_source(source_code, vyper_version=version, base_path=base_path)
+        compiled_src = vvm.compile_source(
+            source_code, vyper_version=version, base_path=base_path
+        )
         compiler_output = compiled_src["<stdin>"]
         return VVMDeployer.from_compiler_output(compiler_output, filename=filename)
 

--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -273,14 +273,17 @@ def load_partial(filename: str, compiler_args=None):
         )
 
 
-def _loads_partial_vvm(source_code: str, version: Version, filename: str):
+def _loads_partial_vvm(source_code: str, version: Version, filename: str, base_path=None):
     global _disk_cache
+
+    if base_path is None:
+        base_path = Path(".")
 
     # install the requested version if not already installed
     vvm.install_vyper(version=version)
 
     def _compile():
-        compiled_src = vvm.compile_source(source_code, vyper_version=version)
+        compiled_src = vvm.compile_source(source_code, vyper_version=version, base_path=base_path)
         compiler_output = compiled_src["<stdin>"]
         return VVMDeployer.from_compiler_output(compiler_output, filename=filename)
 


### PR DESCRIPTION
### What I did
loads_partial_vvm writes to a temporary file, losing the source information in the process. pass in `base_path=<cwd>` which should be "good enough" for 0.3.x vyper

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
