### PR TITLE
feat: namedtuple decoding for vvmcontract structs

### DIFF
--- a/boa/contracts/abi/abi_contract.py
+++ b/boa/contracts/abi/abi_contract.py
@@ -313,6 +313,13 @@ class ABIContract(_BaseEVMContract):
         _log_id, address, topics, data = log_entry
         assert self._address.canonical_address == address
         event_hash = topics[0]
+
+        if event_hash not in self.event_for:
+            # our abi is wrong, we can't decode it. fail loudly.
+            msg = f"can't find event with hash {hex(event_hash)} in abi"
+            msg += f" (possible events: {self.event_for})"
+            raise ValueError(msg)
+
         event_abi = self.event_for[event_hash]
 
         topic_abis = []
@@ -333,6 +340,7 @@ class ABIContract(_BaseEVMContract):
             # so fall back to regular tuple.
             def tuple_typ(*args):
                 return tuple(args)
+
         else:
             tuple_typ = namedtuple(event_abi["name"], tuple_names)
 

--- a/boa/contracts/abi/abi_contract.py
+++ b/boa/contracts/abi/abi_contract.py
@@ -324,7 +324,13 @@ class ABIContract(_BaseEVMContract):
 
         topic_abis = []
         arg_abis = []
-        tuple_names = []
+
+        # add `address` to the tuple. this is prevented from being an
+        # actual fieldname in vyper and solidity since it is a reserved keyword
+        # in both languages. if for some reason some abi actually has a field
+        # named `address`, it will be renamed by namedtuple(rename=True).
+        tuple_names = ["address"]
+
         for item_abi in event_abi["inputs"]:
             is_topic = item_abi["indexed"]
             assert isinstance(is_topic, bool)
@@ -351,9 +357,11 @@ class ABIContract(_BaseEVMContract):
 
         topics_ix = 0
         args_ix = 0
-        xs = []
-        # re-align the evm topic + args lists with the way they appear in the abi
-        # ex. Transfer(indexed address, address, indexed address)
+
+        xs = [Address(address)]
+
+        # re-align the evm topic + args lists with the way they appear in the
+        # abi ex. Transfer(indexed address, address, indexed address)
         for item_abi in event_abi["inputs"]:
             is_topic = item_abi["indexed"]
             if is_topic:

--- a/boa/contracts/abi/abi_contract.py
+++ b/boa/contracts/abi/abi_contract.py
@@ -407,6 +407,12 @@ def _abi_from_json(abi: dict) -> str:
     :param abi: The ABI type to parse.
     :return: The schema string for the given abi type.
     """
+    #[{"stateMutability": "view", "type": "function", "name": "foo",
+    # "inputs": [],
+    # "outputs": [{"name": "", "type": "tuple",
+    #    "components": [{"name": "x", "type": "uint256"}]}]
+    # }]
+
     if "components" in abi:
         components = ",".join([_abi_from_json(item) for item in abi["components"]])
         if abi["type"].startswith("tuple"):
@@ -415,25 +421,26 @@ def _abi_from_json(abi: dict) -> str:
 
     return abi["type"]
 
+
 def _parse_complex(abi: dict, value: Any, name=None) -> str:
     """
     Parses an ABI type into its schema string.
     :param abi: The ABI type to parse.
     :return: The schema string for the given abi type.
     """
-    #[{"stateMutability": "view", "type": "function", "name": "foo", "inputs": [], "outputs": [{"name": "", "type": "tuple", "components": [{"name": "x", "type": "uint256"}]}]}]
-
     # simple case
     if "components" not in abi:
         return value
 
     # complex case
-    components = abi["components"]
-    component_names = [item["name"] for item in components]
     # construct a namedtuple type on the fly
+    components = abi["components"]
     typname = name or abi["name"] or "user_struct"
+    component_names = [item["name"] for item in components]
     typ = namedtuple(typname, component_names)
-    components_parsed = [_parse_complex(item_abi, item) for (item_abi, item) in zip(components, value)]
+    components_parsed = [
+        _parse_complex(item_abi, item) for (item_abi, item) in zip(components, value)
+    ]
     return typ(*components_parsed)
 
 

--- a/boa/contracts/abi/abi_contract.py
+++ b/boa/contracts/abi/abi_contract.py
@@ -550,7 +550,7 @@ def _parse_complex(abi: dict, value: Any, name=None) -> str:
     components = abi["components"]
     typname = name or abi["name"] or "user_struct"
     component_names = [item["name"] for item in components]
-    typ = namedtuple(typname, component_names)
+    typ = namedtuple(typname, component_names, rename=True)
 
     def _leaf(tuple_vals):
         components_parsed = [

--- a/boa/contracts/abi/abi_contract.py
+++ b/boa/contracts/abi/abi_contract.py
@@ -335,14 +335,7 @@ class ABIContract(_BaseEVMContract):
 
             tuple_names.append(item_abi["name"])
 
-        if "from" in tuple_names:
-            # we can't create a namedtuple if one of the fieldnames is `from`,
-            # so fall back to regular tuple.
-            def tuple_typ(*args):
-                return tuple(args)
-
-        else:
-            tuple_typ = namedtuple(event_abi["name"], tuple_names)
+        tuple_typ = namedtuple(event_abi["name"], tuple_names, rename=True)
 
         decoded_topics = []
         for topic_abi, t in zip(topic_abis, topics[1:]):

--- a/boa/contracts/abi/abi_contract.py
+++ b/boa/contracts/abi/abi_contract.py
@@ -250,6 +250,7 @@ class ABIContract(_BaseEVMContract):
         address: Address,
         filename: Optional[str] = None,
         env=None,
+        nowarn=False,
     ):
         super().__init__(name, env, filename=filename, address=address)
         self._abi = abi
@@ -257,7 +258,7 @@ class ABIContract(_BaseEVMContract):
         self._events = events
 
         self._bytecode = self.env.get_code(address)
-        if not self._bytecode:
+        if not self._bytecode and not nowarn:
             warn(
                 f"Requested {self} but there is no bytecode at that address!",
                 stacklevel=2,
@@ -472,13 +473,13 @@ class ABIContractFactory:
     def from_abi_dict(cls, abi, name="<anonymous contract>", filename=None):
         return cls(name, abi, filename)
 
-    def at(self, address: Address | str) -> ABIContract:
+    def at(self, address: Address | str, nowarn=False) -> ABIContract:
         """
         Create an ABI contract object for a deployed contract at `address`.
         """
         address = Address(address)
         contract = ABIContract(
-            self._name, self._abi, self.functions, self.events, address, self.filename
+            self._name, self._abi, self.functions, self.events, address, self.filename,nowarn=nowarn
         )
 
         contract.env.register_contract(address, contract)

--- a/boa/contracts/abi/abi_contract.py
+++ b/boa/contracts/abi/abi_contract.py
@@ -294,7 +294,8 @@ class ABIContract(_BaseEVMContract):
     def event_for(self):
         # [{"name": "Bar", "inputs":
         #   [{"name": "x", "type": "uint256", "indexed": false},
-        #   {"name": "y", "type": "tuple", "components": [{"name": "x", "type": "uint256"}], "indexed": false}],
+        #   {"name": "y", "type": "tuple", "components":
+        #     [{"name": "x", "type": "uint256"}], "indexed": false}],
         # "anonymous": false, "type": "event"},
         # }]
         ret = {}
@@ -550,7 +551,8 @@ def _parse_complex(abi: dict, value: Any, name=None) -> str:
     components = abi["components"]
     typname = name or abi["name"] or "user_struct"
     component_names = [item["name"] for item in components]
-    typ = namedtuple(typname, component_names, rename=True)
+
+    typ = namedtuple(typname, component_names, rename=True)  # type: ignore[misc]
 
     def _leaf(tuple_vals):
         components_parsed = [

--- a/boa/contracts/abi/abi_contract.py
+++ b/boa/contracts/abi/abi_contract.py
@@ -479,7 +479,13 @@ class ABIContractFactory:
         """
         address = Address(address)
         contract = ABIContract(
-            self._name, self._abi, self.functions, self.events, address, self.filename,nowarn=nowarn
+            self._name,
+            self._abi,
+            self.functions,
+            self.events,
+            address,
+            self.filename,
+            nowarn=nowarn,
         )
 
         contract.env.register_contract(address, contract)

--- a/boa/contracts/abi/abi_contract.py
+++ b/boa/contracts/abi/abi_contract.py
@@ -330,21 +330,25 @@ class ABIContract(_BaseEVMContract):
 
         decoded_args = abi_decode(args_selector, data)
 
-        t_i = 0
-        a_i = 0
+        topics_ix = 0
+        args_ix = 0
         xs = []
         # re-align the evm topic + args lists with the way they appear in the abi
         # ex. Transfer(indexed address, address, indexed address)
         for item_abi in event_abi["inputs"]:
             is_topic = item_abi["indexed"]
             if is_topic:
-                # topic abi is currently never complex, but use _parse_complex as
-                # future-proofing mechanism
-                xs.append(_parse_complex(topic_abis[t_i], decoded_topics[t_i]))
-                t_i += 1
+                abi = topic_abis[topics_ix]
+                topic = decoded_topics[topics_ix]
+                # topic abi is currently never complex, but use _parse_complex
+                # as future-proofing mechanism
+                xs.append(_parse_complex(abi, topic))
+                topics_ix += 1
             else:
-                xs.append(_parse_complex(arg_abis[a_i], decoded_args[a_i]))
-                a_i += 1
+                abi = arg_abis[args_ix]
+                arg = decoded_args[args_ix]
+                xs.append(_parse_complex(abi, arg))
+                args_ix += 1
 
         return tuple_typ(*xs)
 

--- a/boa/contracts/abi/abi_contract.py
+++ b/boa/contracts/abi/abi_contract.py
@@ -328,7 +328,13 @@ class ABIContract(_BaseEVMContract):
 
             tuple_names.append(item_abi["name"])
 
-        tuple_typ = namedtuple(event_abi["name"], tuple_names)
+        if "from" in tuple_names:
+            # we can't create a namedtuple if one of the fieldnames is `from`,
+            # so fall back to regular tuple.
+            def tuple_typ(*args):
+                return tuple(args)
+        else:
+            tuple_typ = namedtuple(event_abi["name"], tuple_names)
 
         decoded_topics = []
         for topic_abi, t in zip(topic_abis, topics[1:]):

--- a/boa/contracts/base_evm_contract.py
+++ b/boa/contracts/base_evm_contract.py
@@ -72,7 +72,7 @@ class _BaseEVMContract:
 
         return computation._log_entries
 
-    def get_logs(self, computation=None, include_child_logs=True):
+    def get_logs(self, computation=None, include_child_logs=True, strict=True):
         if computation is None:
             computation = self._computation
 
@@ -87,9 +87,16 @@ class _BaseEVMContract:
             logger_address = e[1]
             c = self.env.lookup_contract(logger_address)
             if c is not None:
-                ret.append(c.decode_log(e))
+                try:
+                    decoded_log = c.decode_log(e)
+                except Exception as exc:
+                    if strict:
+                        raise exc
+                    else:
+                        decoded_log = RawEvent(e)
             else:
-                ret.append(RawEvent(e))
+                decoded_log = RawEvent(e)
+            ret.append(decoded_log)
 
         return ret
 

--- a/boa/contracts/base_evm_contract.py
+++ b/boa/contracts/base_evm_contract.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from eth.abc import ComputationAPI
 
@@ -11,6 +11,7 @@ from boa.util.exceptions import strip_internal_frames
 if TYPE_CHECKING:
     from boa.contracts.vyper.vyper_contract import DevReason
     from boa.vm.py_evm import titanoboa_computation
+
 
 @dataclass
 class RawEvent:

--- a/boa/contracts/base_evm_contract.py
+++ b/boa/contracts/base_evm_contract.py
@@ -12,6 +12,10 @@ if TYPE_CHECKING:
     from boa.contracts.vyper.vyper_contract import DevReason
     from boa.vm.py_evm import titanoboa_computation
 
+@dataclass
+class RawEvent:
+    event_data: Any
+
 
 class _BaseEVMContract:
     """
@@ -56,6 +60,37 @@ class _BaseEVMContract:
             # avoid assert, in pytest it would call repr(self) which segfaults
             raise RuntimeError("Contract address is not set")
         return self._address
+
+    # ## handling events
+    def _get_logs(self, computation, include_child_logs):
+        if computation is None:
+            return []
+
+        if include_child_logs:
+            return list(computation.get_raw_log_entries())
+
+        return computation._log_entries
+
+    def get_logs(self, computation=None, include_child_logs=True):
+        if computation is None:
+            computation = self._computation
+
+        entries = self._get_logs(computation, include_child_logs)
+
+        # py-evm log format is (log_id, topics, data)
+        # sort on log_id
+        entries = sorted(entries)
+
+        ret = []
+        for e in entries:
+            logger_address = e[1]
+            c = self.env.lookup_contract(logger_address)
+            if c is not None:
+                ret.append(c.decode_log(e))
+            else:
+                ret.append(RawEvent(e))
+
+        return ret
 
 
 class StackTrace(list):  # list[str|ErrorDetail]

--- a/boa/contracts/vvm/vvm_contract.py
+++ b/boa/contracts/vvm/vvm_contract.py
@@ -59,6 +59,9 @@ class VVMDeployer:
             bytecode=self.bytecode + encoded_args, **kwargs
         )
 
+        # set nowarn=True. if there was a problem in the deploy, it will
+        # be caught at computation.is_error, so the warning is redundant
+        # (and annoying!)
         ret = self.at(address, nowarn=True)
         if contract_name is not None:
             # override contract name

--- a/boa/contracts/vvm/vvm_contract.py
+++ b/boa/contracts/vvm/vvm_contract.py
@@ -59,10 +59,10 @@ class VVMDeployer:
             bytecode=self.bytecode + encoded_args, **kwargs
         )
 
-        # TODO: pass thru contract_name
-        # NOTE: if computation.is_error, `self.at()` will raise a warning
-        # in the future we should refactor so that the warning is silenced
-        ret = self.at(address)
+        ret = self.at(address, nowarn=True)
+        if contract_name is not None:
+            # override contract name
+            ret.contract_name = contract_name
 
         if computation.is_error:
             ret.handle_error(computation)
@@ -101,5 +101,5 @@ class VVMDeployer:
     def __call__(self, *args, **kwargs):
         return self.deploy(*args, **kwargs)
 
-    def at(self, address):
-        return self.factory.at(address)
+    def at(self, address, nowarn=False):
+        return self.factory.at(address, nowarn=nowarn)

--- a/boa/contracts/vvm/vvm_contract.py
+++ b/boa/contracts/vvm/vvm_contract.py
@@ -1,4 +1,5 @@
 from functools import cached_property
+from typing import Optional
 
 from boa.contracts.abi.abi_contract import ABIContractFactory, ABIFunction
 from boa.environment import Env
@@ -12,27 +13,30 @@ class VVMDeployer:
     can interact with new versions using the ABI definition.
     """
 
-    def __init__(self, abi, bytecode, filename):
+    def __init__(self, abi, bytecode, name, filename):
         """
         Initialize a VVMDeployer instance.
         :param abi: The contract's ABI.
         :param bytecode: The contract's bytecode.
         :param filename: The filename of the contract.
         """
-        self.abi = abi
-        self.bytecode = bytecode
-        self.filename = filename
+        self.abi: dict = abi
+        self.bytecode: bytes = bytecode
+        self.name: Optional[str] = name
+        self.filename: str = filename
 
     @classmethod
-    def from_compiler_output(cls, compiler_output, filename):
+    def from_compiler_output(cls, compiler_output, name, filename):
         abi = compiler_output["abi"]
         bytecode_nibbles = compiler_output["bytecode"]
         bytecode = bytes.fromhex(bytecode_nibbles.removeprefix("0x"))
-        return cls(abi, bytecode, filename)
+        return cls(abi, bytecode, name, filename)
 
     @cached_property
     def factory(self):
-        return ABIContractFactory.from_abi_dict(self.abi)
+        return ABIContractFactory.from_abi_dict(
+            self.abi, name=self.name, filename=self.filename
+        )
 
     @cached_property
     def constructor(self):

--- a/boa/contracts/vvm/vvm_contract.py
+++ b/boa/contracts/vvm/vvm_contract.py
@@ -51,7 +51,9 @@ class VVMDeployer:
         if env is None:
             env = Env.get_singleton()
 
-        address, computation = env.deploy(bytecode=self.bytecode + encoded_args, **kwargs)
+        address, computation = env.deploy(
+            bytecode=self.bytecode + encoded_args, **kwargs
+        )
         # TODO: pass thru contract_name
         ret = self.at(address)
 

--- a/boa/contracts/vvm/vvm_contract.py
+++ b/boa/contracts/vvm/vvm_contract.py
@@ -54,7 +54,10 @@ class VVMDeployer:
         address, computation = env.deploy(
             bytecode=self.bytecode + encoded_args, **kwargs
         )
+
         # TODO: pass thru contract_name
+        # NOTE: if computation.is_error, `self.at()` will raise a warning
+        # in the future we should refactor so that the warning is silenced
         ret = self.at(address)
 
         if computation.is_error:

--- a/boa/contracts/vyper/event.py
+++ b/boa/contracts/vyper/event.py
@@ -30,6 +30,3 @@ class Event:
         return f"{self.event_type.name}({args})"
 
 
-@dataclass
-class RawEvent:
-    event_data: Any

--- a/boa/contracts/vyper/event.py
+++ b/boa/contracts/vyper/event.py
@@ -28,5 +28,3 @@ class Event:
 
         args = ", ".join(f"{k}={v}" for k, v in b)
         return f"{self.event_type.name}({args})"
-
-

--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -4,7 +4,7 @@ from importlib.abc import MetaPathFinder
 from importlib.machinery import SourceFileLoader
 from importlib.util import spec_from_loader
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import vvm
 import vyper
@@ -256,8 +256,7 @@ def loads_partial(
     if specifier_set is not None and not specifier_set.contains(vyper.__version__):
         version = _pick_vyper_version(specifier_set)
         filename = str(filename)  # help mypy
-        # TODO: pass name to loads_partial_vvm, not filename
-        return _loads_partial_vvm(source_code, version, filename)
+        return _loads_partial_vvm(source_code, version, name, filename)
 
     compiler_args = compiler_args or {}
 
@@ -274,7 +273,7 @@ def load_partial(filename: str, compiler_args=None):
 
 
 def _loads_partial_vvm(
-    source_code: str, version: Version, filename: str, base_path=None
+    source_code: str, version: Version, name: Optional[str], filename: str, base_path=None
 ):
     global _disk_cache
 
@@ -289,7 +288,9 @@ def _loads_partial_vvm(
             source_code, vyper_version=version, base_path=base_path
         )
         compiler_output = compiled_src["<stdin>"]
-        return VVMDeployer.from_compiler_output(compiler_output, filename=filename)
+        return VVMDeployer.from_compiler_output(
+            compiler_output, name=name, filename=filename
+        )
 
     # Ensure the cache is initialized
     if _disk_cache is None:

--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -273,7 +273,9 @@ def load_partial(filename: str, compiler_args=None):
         )
 
 
-def _loads_partial_vvm(source_code: str, version: Version, filename: str, base_path=None):
+def _loads_partial_vvm(
+    source_code: str, version: Version, filename: str, base_path=None
+):
     global _disk_cache
 
     if base_path is None:
@@ -283,7 +285,9 @@ def _loads_partial_vvm(source_code: str, version: Version, filename: str, base_p
     vvm.install_vyper(version=version)
 
     def _compile():
-        compiled_src = vvm.compile_source(source_code, vyper_version=version, base_path=base_path)
+        compiled_src = vvm.compile_source(
+            source_code, vyper_version=version, base_path=base_path
+        )
         compiler_output = compiled_src["<stdin>"]
         return VVMDeployer.from_compiler_output(compiler_output, filename=filename)
 

--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -273,7 +273,11 @@ def load_partial(filename: str, compiler_args=None):
 
 
 def _loads_partial_vvm(
-    source_code: str, version: Version, name: Optional[str], filename: str, base_path=None
+    source_code: str,
+    version: Version,
+    name: Optional[str],
+    filename: str,
+    base_path=None,
 ):
     global _disk_cache
 

--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -310,6 +310,13 @@ def _loads_partial_vvm(
 
     # Check the cache and return the result if available
     ret = _disk_cache.caching_lookup(cache_key, _compile)
+
+    # backwards compatibility: old versions of boa returned a VVMDeployer.
+    # here we detect the case and invalidate the cache so it can recompile.
+    if isinstance(ret, VVMDeployer):
+        _disk_cache.invalidate(cache_key)
+        ret = _disk_cache.caching_lookup(cache_key, _compile)
+
     return _handle_output(ret)
 
 

--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -273,14 +273,17 @@ def load_partial(filename: str, compiler_args=None):
         )
 
 
-def _loads_partial_vvm(source_code: str, version: Version, filename: str):
+def _loads_partial_vvm(source_code: str, version: Version, filename: str, base_path=None):
     global _disk_cache
+
+    if base_path is None:
+        base_path = Path(".")
 
     # install the requested version if not already installed
     vvm.install_vyper(version=version)
 
     def _compile():
-        compiled_src = vvm.compile_source(source_code, vyper_version=version)
+        compiled_src = vvm.compile_source(source_code, vyper_version=version, base_path=base_path)
         compiler_output = compiled_src["<stdin>"]
         return VVMDeployer.from_compiler_output(compiler_output, filename=filename)
 

--- a/boa/util/disk_cache.py
+++ b/boa/util/disk_cache.py
@@ -53,6 +53,11 @@ class DiskCache:
         digest = hashlib.sha256(preimage).digest().hex()
         return self.cache_dir.joinpath(f"{self.version_salt}/{digest}.pickle")
 
+    def invalidate(self, string):
+        p = self.cal(string)
+        with _silence_io_errors():
+            p.unlink()
+
     # look up x in the cal; on a miss, write back to the cache
     def caching_lookup(self, string, func):
         gc_interval = self.ttl // 10

--- a/tests/integration/fork/test_logs_fork.py
+++ b/tests/integration/fork/test_logs_fork.py
@@ -2,7 +2,7 @@ import pytest
 from vyper.utils import keccak256
 
 import boa
-from boa.contracts.vyper.event import RawEvent
+from boa.contracts.base_evm_contract import RawEvent
 
 WETH_ADDRESS = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
 

--- a/tests/unitary/contracts/vvm/test_vvm.py
+++ b/tests/unitary/contracts/vvm/test_vvm.py
@@ -81,6 +81,15 @@ def test_cache_clean_name():
     assert deployer1.name == "foo"
     assert deployer2.name == "bar"
 
+def test_ctor_revert():
+    code = """
+# pragma version 0.3.10
+@external
+def __init__():
+    raise
+    """
+    with boa.reverts():
+        boa.loads(code)
 
 def test_logs():
     code = """

--- a/tests/unitary/contracts/vvm/test_vvm.py
+++ b/tests/unitary/contracts/vvm/test_vvm.py
@@ -92,6 +92,7 @@ def test_vvm_name_forwarding():
     c = deployer1.deploy(100, contract_name="baz")
     assert c.contract_name == "baz"
 
+
 def test_ctor_revert():
     # test that revert in ctor throws proper BoaError
     code = """
@@ -102,6 +103,7 @@ def __init__():
     """
     with boa.reverts():
         boa.loads(code)
+
 
 def test_logs():
     # test namedtuple decoder for logs

--- a/tests/unitary/contracts/vvm/test_vvm.py
+++ b/tests/unitary/contracts/vvm/test_vvm.py
@@ -69,3 +69,14 @@ def test_forward_args_on_deploy():
     contract = contract_vvm_deployer.deploy(43, override_address=random_addy)
 
     assert random_addy == contract.address
+
+
+def test_cache_clean_name():
+    with open(mock_3_10_path) as f:
+        code = f.read()
+
+    deployer1 = boa.loads_partial(code, name="foo")
+    deployer2 = boa.loads_partial(code, name="bar")
+
+    assert deployer1.name == "foo"
+    assert deployer2.name == "bar"

--- a/tests/unitary/contracts/vvm/test_vvm.py
+++ b/tests/unitary/contracts/vvm/test_vvm.py
@@ -118,13 +118,16 @@ def foo(x: uint256, y: address):
 
     assert type(logs[1]).__name__ == "MyEvent2"
     # namedtuple renames things with "from" to _1, _2 etc
-    assert logs[1]._0 == boa.env.eoa
+    assert logs[1]._1 == boa.env.eoa
     assert logs[1].addr == addr
 
     assert type(logs[2]).__name__ == "MyEvent2"
-    assert logs[2]._0 == addr
+    assert logs[2]._1 == addr
     assert logs[2].addr == boa.env.eoa
 
     assert type(logs[3]).__name__ == "MyEvent3"
     assert logs[3].addr == addr
-    assert logs[3]._1 == boa.env.eoa
+    assert logs[3]._2 == boa.env.eoa
+
+    for log in logs:
+        assert log.address == c.address

--- a/tests/unitary/contracts/vvm/test_vvm.py
+++ b/tests/unitary/contracts/vvm/test_vvm.py
@@ -71,7 +71,9 @@ def test_forward_args_on_deploy():
     assert random_addy == contract.address
 
 
-def test_cache_clean_name():
+def test_vvm_name_forwarding():
+    # test that names passed to loads_partial() and deploy()
+    # get forwarded to the final contract properly.
     with open(mock_3_10_path) as f:
         code = f.read()
 
@@ -81,7 +83,17 @@ def test_cache_clean_name():
     assert deployer1.name == "foo"
     assert deployer2.name == "bar"
 
+    c1 = deployer1.deploy(100)
+    c2 = deployer2.deploy(101)
+    assert c1.contract_name == "foo"
+    assert c2.contract_name == "bar"
+
+    # test override in deploy()
+    c = deployer1.deploy(100, contract_name="baz")
+    assert c.contract_name == "baz"
+
 def test_ctor_revert():
+    # test that revert in ctor throws proper BoaError
     code = """
 # pragma version 0.3.10
 @external
@@ -92,6 +104,7 @@ def __init__():
         boa.loads(code)
 
 def test_logs():
+    # test namedtuple decoder for logs
     code = """
 # pragma version 0.3.10
 
@@ -144,6 +157,7 @@ def foo(x: uint256, y: address):
 
 
 def test_nested_logs():
+    # test namedtuple decoder for nested logs
     code1 = """
 # pragma version 0.3.10
 event Foo:
@@ -199,6 +213,7 @@ def bar(target: CallFoo):
 
 
 def test_structs():
+    # test namedtuple decoder for structs
     code = """
 # pragma version 0.3.10
 

--- a/tests/unitary/contracts/vvm/test_vvm.py
+++ b/tests/unitary/contracts/vvm/test_vvm.py
@@ -131,3 +131,48 @@ def foo(x: uint256, y: address):
 
     for log in logs:
         assert log.address == c.address
+
+
+def test_structs():
+    code = """
+# pragma version 0.3.10
+
+struct MyStruct1:
+    x: uint256
+
+struct MyStruct2:
+    _from: address
+    x: uint256
+
+@external
+def foo(x: uint256) -> MyStruct1:
+    return MyStruct1({x: x})
+
+@external
+def bar(_from: address, x: uint256) -> MyStruct2:
+    return MyStruct2({_from: _from, x: x})
+
+@external
+def baz(x: uint256, _from: address, y: uint256) -> (MyStruct1, MyStruct2):
+    return MyStruct1({x: x}), MyStruct2({_from: _from, x: y})
+    """
+
+    c = boa.loads(code)
+
+    t = c.foo(1)
+    # don't get correct struct names from the abi.
+    # assert type(t).__name__ == "MyStruct1"
+    assert t.x == 1
+
+    addy = boa.env.generate_address()
+    s = c.bar(addy, 2)
+    # assert type(s).__name__ == "MyStruct2"
+    assert s._0 == addy  # test renames
+    assert s.x == 2
+
+    u, v = c.baz(3, addy, 4)
+    # assert type(u).__name__ == "MyStruct1"
+    assert u.x == 3
+    # assert type(v).__name__ == "MyStruct2"
+    assert v._0 == addy
+    assert v.x == 4

--- a/tests/unitary/contracts/vvm/test_vvm.py
+++ b/tests/unitary/contracts/vvm/test_vvm.py
@@ -95,7 +95,8 @@ event MyEvent2:
 
 event MyEvent3:
     addr: address
-    _from: address
+    # throw in out-of-order indexed field for fun
+    _from: indexed(address)
 
 @external
 def foo(x: uint256, y: address):

--- a/tests/unitary/utils/test_cache.py
+++ b/tests/unitary/utils/test_cache.py
@@ -47,19 +47,19 @@ x: constant(int128) = 1000
         assert mock_compile.call_count == 0
 
         # First call should hit vvm.compile_source
-        test1 = _loads_partial_vvm(code, version, "fake_file.vy")
+        test1 = _loads_partial_vvm(code, version, None, "fake_file.vy")
         assert mock_compile.call_count == 1
 
         # Second call should hit the cache
-        test2 = _loads_partial_vvm(code, version, "fake_file.vy")
+        test2 = _loads_partial_vvm(code, version, None, "fake_file.vy")
         assert mock_compile.call_count == 1
 
         # using a different filename should also hit the cache
-        test3 = _loads_partial_vvm(code, version, "fake_fileeeee.vy")
+        test3 = _loads_partial_vvm(code, version, None, "fake_fileeeee.vy")
         assert mock_compile.call_count == 1
 
         # using a different vyper version should *miss* the cache
-        _loads_partial_vvm(code, version2, "fake_file.vy")
+        _loads_partial_vvm(code, version2, None, "fake_file.vy")
         assert mock_compile.call_count == 2
 
     assert test1.abi == test2.abi == test3.abi


### PR DESCRIPTION
### What I did
- add namedtuple decoding for VVMContract structs
- also namedtuple decoding for VVMContract events
  - IMPORTANT: this is different than the existing get_logs API (for VyperContract). probably VyperContract should have the namedtuple decoding for get_logs as well
- add `handle_error()` in VVMDeployer.deploy() to properly raise BoaErrors that occur in the ctor

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
