### PR TITLE
feat: prevhash in forked environment

### DIFF
--- a/boa/vm/py_evm.py
+++ b/boa/vm/py_evm.py
@@ -416,7 +416,7 @@ class PyEVM:
         self.patch.block_number = int(block_info["number"], 16)
         self.patch.chain_id = int(rpc.fetch("eth_chainId", []), 16)
         
-        self.patch.prev_hashes = [bytes.fromhex("0"* 32)] * 255  # placeholder not to fetch all prev hashes
+        self.patch.prev_hashes = [b"\x00" * 32] * 255  # placeholder not to fetch all prev hashes
         self.patch.prev_hashes[0] = bytes.fromhex(block_info["parentHash"].removeprefix('0x')) # this one we fetched
 
         self.vm.state._account_db._rpc._init_db()

--- a/boa/vm/py_evm.py
+++ b/boa/vm/py_evm.py
@@ -415,6 +415,9 @@ class PyEVM:
         self.patch.timestamp = int(block_info["timestamp"], 16)
         self.patch.block_number = int(block_info["number"], 16)
         self.patch.chain_id = int(rpc.fetch("eth_chainId", []), 16)
+        
+        self.patch.prev_hashes = [bytes.fromhex("0"* 32)] * 255  # placeholder not to fetch all prev hashes
+        self.patch.prev_hashes[0] = bytes.fromhex(block_info["parentHash"][2:]) # this one we fetched
 
         self.vm.state._account_db._rpc._init_db()
 

--- a/boa/vm/py_evm.py
+++ b/boa/vm/py_evm.py
@@ -415,9 +415,14 @@ class PyEVM:
         self.patch.timestamp = int(block_info["timestamp"], 16)
         self.patch.block_number = int(block_info["number"], 16)
         self.patch.chain_id = int(rpc.fetch("eth_chainId", []), 16)
-        
-        self.patch.prev_hashes = [b"\x00" * 32] * 255  # placeholder not to fetch all prev hashes
-        self.patch.prev_hashes[0] = bytes.fromhex(block_info["parentHash"].removeprefix('0x')) # this one we fetched
+
+        # placeholder not to fetch all prev hashes
+        # (NOTE: we should document this)
+        self.patch.prev_hashes = [b"\x00" * 32] * 255
+        # this one we already fetched
+        self.patch.prev_hashes[0] = bytes.fromhex(
+            block_info["parentHash"].removeprefix("0x")
+        )
 
         self.vm.state._account_db._rpc._init_db()
 

--- a/boa/vm/py_evm.py
+++ b/boa/vm/py_evm.py
@@ -417,7 +417,7 @@ class PyEVM:
         self.patch.chain_id = int(rpc.fetch("eth_chainId", []), 16)
         
         self.patch.prev_hashes = [bytes.fromhex("0"* 32)] * 255  # placeholder not to fetch all prev hashes
-        self.patch.prev_hashes[0] = bytes.fromhex(block_info["parentHash"][2:]) # this one we fetched
+        self.patch.prev_hashes[0] = bytes.fromhex(block_info["parentHash"].removeprefix('0x')) # this one we fetched
 
         self.vm.state._account_db._rpc._init_db()
 

--- a/tests/integration/fork/test_block_variables.py
+++ b/tests/integration/fork/test_block_variables.py
@@ -36,8 +36,6 @@ def test_prev_hash():
     def get_prevhash() -> bytes32:
         return block.prevhash
     """)
-    # print(getter_contract.get_prevhash())
-    # assert True
     assert getter_contract.get_prevhash() == list(boa.env.evm.patch.prev_hashes)[0]
 
 

--- a/tests/integration/fork/test_block_variables.py
+++ b/tests/integration/fork/test_block_variables.py
@@ -1,49 +1,57 @@
-import pytest
-
 import boa
 
 
 def test_block_number():
-    getter_contract = boa.loads("""
+    getter_contract = boa.loads(
+        """
     @external
     def get_block_number() -> uint256:
         return block.number
-    """)
+    """
+    )
     assert getter_contract.get_block_number() == boa.env.evm.patch.block_number
 
 
 def test_block_timestamp():
-    getter_contract = boa.loads("""
+    getter_contract = boa.loads(
+        """
     @external
     def get_block_timestamp() -> uint256:
         return block.timestamp
-    """)
+    """
+    )
     assert getter_contract.get_block_timestamp() == boa.env.evm.patch.timestamp
 
 
 def test_chain_id():
-    getter_contract = boa.loads("""
+    getter_contract = boa.loads(
+        """
     @external
     def get_chain_id() -> uint256:
         return chain.id
-    """)
+    """
+    )
     assert getter_contract.get_chain_id() == boa.env.evm.patch.chain_id
 
 
 def test_prev_hash():
-    getter_contract = boa.loads("""
+    getter_contract = boa.loads(
+        """
     @external
     def get_prevhash() -> bytes32:
         return block.prevhash
-    """)
+    """
+    )
     assert getter_contract.get_prevhash() == list(boa.env.evm.patch.prev_hashes)[0]
 
 
 def test_block_hash():  # only works for previous block
     current_block = boa.env.evm.patch.block_number
-    getter_contract = boa.loads(f"""
+    getter_contract = boa.loads(
+        f"""
     @external
     def get_blockhash() -> bytes32:
         return blockhash({current_block-1})
-    """)
+    """
+    )
     assert getter_contract.get_blockhash() == list(boa.env.evm.patch.prev_hashes)[0]

--- a/tests/integration/fork/test_block_variables.py
+++ b/tests/integration/fork/test_block_variables.py
@@ -1,0 +1,51 @@
+import pytest
+
+import boa
+
+
+def test_block_number():
+    getter_contract = boa.loads("""
+    @external
+    def get_block_number() -> uint256:
+        return block.number
+    """)
+    assert getter_contract.get_block_number() == boa.env.evm.patch.block_number
+
+
+def test_block_timestamp():
+    getter_contract = boa.loads("""
+    @external
+    def get_block_timestamp() -> uint256:
+        return block.timestamp
+    """)
+    assert getter_contract.get_block_timestamp() == boa.env.evm.patch.timestamp
+
+
+def test_chain_id():
+    getter_contract = boa.loads("""
+    @external
+    def get_chain_id() -> uint256:
+        return chain.id
+    """)
+    assert getter_contract.get_chain_id() == boa.env.evm.patch.chain_id
+
+
+def test_prev_hash():
+    getter_contract = boa.loads("""
+    @external
+    def get_prevhash() -> bytes32:
+        return block.prevhash
+    """)
+    # print(getter_contract.get_prevhash())
+    # assert True
+    assert getter_contract.get_prevhash() == list(boa.env.evm.patch.prev_hashes)[0]
+
+
+def test_block_hash():  # only works for previous block
+    current_block = boa.env.evm.patch.block_number
+    getter_contract = boa.loads(f"""
+    @external
+    def get_blockhash() -> bytes32:
+        return blockhash({current_block-1})
+    """)
+    assert getter_contract.get_blockhash() == list(boa.env.evm.patch.prev_hashes)[0]

--- a/tests/unitary/jupyter/test_browser.py
+++ b/tests/unitary/jupyter/test_browser.py
@@ -113,7 +113,12 @@ def mock_fork(mock_callback):
     mock_callback("evm_snapshot", "0x123456")
     mock_callback("evm_revert", "0x12345678")
     mock_callback("eth_chainId", "0x1")
-    data = {"number": "0x123", "timestamp": "0x65bbb460", "blockHash": "0x1234", "parentHash": "0x5678"}
+    data = {
+        "number": "0x123",
+        "timestamp": "0x65bbb460",
+        "blockHash": "0x1234",
+        "parentHash": "0x5678",
+    }
     mock_callback("eth_getBlockByNumber", data)
 
 

--- a/tests/unitary/jupyter/test_browser.py
+++ b/tests/unitary/jupyter/test_browser.py
@@ -113,7 +113,7 @@ def mock_fork(mock_callback):
     mock_callback("evm_snapshot", "0x123456")
     mock_callback("evm_revert", "0x12345678")
     mock_callback("eth_chainId", "0x1")
-    data = {"number": "0x123", "timestamp": "0x65bbb460"}
+    data = {"number": "0x123", "timestamp": "0x65bbb460", "blockHash": "0x1234", "parentHash": "0x5678"}
     mock_callback("eth_getBlockByNumber", data)
 
 


### PR DESCRIPTION
### What I did
Added the ability to access real `block.prevhash` as well as `blockhash(block.number - 1)` from vyper contracts.
Implemented simple tests to validate functionality, and some neighboring tests

### How I did it
Added the following lines to `boa/vm/py_evm.py
`:
```
self.patch.prev_hashes = [bytes.fromhex("0"* 32)] * 255  # placeholder not to fetch all prev hashes
self.patch.prev_hashes[0] = bytes.fromhex(block_info["parentHash"][2:]) # this one we fetched

```

### How to verify it
Run the following test command:
`pytest tests/integration/fork/test_block_variables.py -s
`
### Description for the changelog
Added support for accessing block.prevhash and blockhash(block.number - 1)

### Cute Animal Picture
```
 /\_/\  
( o.o )  
(> ♡ <)  

```