### PR TITLE
fix: add _computation after VVMContract.deploy

### DIFF
--- a/boa/contracts/vvm/vvm_contract.py
+++ b/boa/contracts/vvm/vvm_contract.py
@@ -66,6 +66,7 @@ class VVMDeployer:
         if contract_name is not None:
             # override contract name
             ret.contract_name = contract_name
+        ret._computation = computation
 
         if computation.is_error:
             ret.handle_error(computation)


### PR DESCRIPTION
ensure _computation is set properly after VVMContract.deploy is run

### What I did

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
