### PR TITLE
add kwarg nowarn=False to .at()

### DIFF
--- a/boa/contracts/vyper/vyper_contract.py
+++ b/boa/contracts/vyper/vyper_contract.py
@@ -117,13 +117,13 @@ class VyperDeployer:
         return ret
 
     # TODO: allow `env=` kwargs and so on
-    def at(self, address: Any) -> "VyperContract":
+    def at(self, address: Any, nowarn=False) -> "VyperContract":
         address = Address(address)
 
         ret = self.deploy(override_address=address, skip_initcode=True)
         bytecode = ret.env.get_code(address)
 
-        ret._set_bytecode(bytecode)
+        ret._set_bytecode(bytecode, nowarn=nowarn)
 
         ret.env.register_contract(address, ret)
         return ret
@@ -604,12 +604,12 @@ class VyperContract(_BaseVyperContract):
             return source_map
 
     # manually set the runtime bytecode, instead of using deploy
-    def _set_bytecode(self, bytecode: bytes) -> None:
+    def _set_bytecode(self, bytecode: bytes, nowarn=False) -> None:
         to_check = bytecode
         if self.data_section_size != 0:
             to_check = bytecode[: -self.data_section_size]
         assert isinstance(self.compiler_data, CompilerData)
-        if to_check != self.compiler_data.bytecode_runtime:
+        if to_check != self.compiler_data.bytecode_runtime and not nowarn:
             warnings.warn(
                 f"casted bytecode does not match compiled bytecode at {self}",
                 stacklevel=2,

--- a/boa/vm/py_evm.py
+++ b/boa/vm/py_evm.py
@@ -299,7 +299,7 @@ class titanoboa_computation:
             proxied_address = extract_eip1167_address(runtime_bytecode)
             proxied_contract = cls.env.lookup_contract(proxied_address)
             if proxied_contract is not None and hasattr(proxied_contract, "deployer"):
-                contract = proxied_contract.deployer.at(contract_address)
+                contract = proxied_contract.deployer.at(contract_address, nowarn=True)
                 if hasattr(contract, "created_from"):
                     contract.created_from = Address(msg.sender)
                 cls.env.register_contract(contract_address, contract)


### PR DESCRIPTION
sometimes you want to suppress the warning on purpose (like for minimal proxy contracts)

### What I did

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
