### PR TITLE
Allow `at()` to be used with both contracts and blueprints

### DIFF
--- a/boa/contracts/vyper/vyper_contract.py
+++ b/boa/contracts/vyper/vyper_contract.py
@@ -160,6 +160,15 @@ class _BaseVyperContract(_BaseEVMContract):
     def _constants(self):
         return ConstantsModel(self.compiler_data)
 
+    @cached_property
+    def deployer(self):
+        # TODO add test
+        return VyperDeployer(self.compiler_data, filename=self.filename)
+
+    # is this actually useful?
+    def at(self, address):
+        return self.deployer.at(address)
+
 
 # create a blueprint for use with `create_from_blueprint`.
 # uses a ERC5202 preamble, when calling `create_from_blueprint` will
@@ -200,10 +209,6 @@ class VyperBlueprint(_BaseVyperContract):
         self._address = Address(addr)
 
         self.env.register_blueprint(compiler_data.bytecode, self)
-
-    @cached_property
-    def deployer(self):
-        return VyperDeployer(self.compiler_data, filename=self.filename)
 
 
 class FrameDetail(dict):
@@ -628,15 +633,6 @@ class VyperContract(_BaseVyperContract):
     @cached_property
     def _immutables(self):
         return ImmutablesModel(self)
-
-    @cached_property
-    def deployer(self):
-        # TODO add test
-        return VyperDeployer(self.compiler_data, filename=self.filename)
-
-    # is this actually useful?
-    def at(self, address):
-        return self.deployer.at(address)
 
     def _get_fn_from_computation(self, computation):
         node = self.find_source_of(computation)


### PR DESCRIPTION
### What I did

Allow for the use of `at()` with blueprint contracts. Currently:

```
@pytest.fixture
def token_blueprint() -> VyperContract:
    return TokenBlueprint.deploy_as_blueprint()

@pytest.fixture
def token_factory(token_blueprint) -> VyperContract:
    return TokenFactory.deploy(token_blueprint)


def test_deployment(token_factory, token_blueprint):
    token_address = token_factory.deploy_token("Snek", "SNK", 18, "Snek", "1")
    print(f"Token deployed at: {token_address}")
    factory = token_factory.at(token_factory.address) # This will work
    token = token_blueprint.at(token_address) # This will not

```

Right now `token_blueprint.at(token_address)` does not work and one would have to use `token_blueprint.deployer.at(token_address)` which is  inconsistent with the behavior of regular `VyperContracts`.

### How I did it

Moved `at` (which was only in `VyperContract`) and `deployer` (which was both in `VyperContract` and `VyperBlueprint`) to the `_BaseVyperContract` class

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://github.com/user-attachments/assets/b1124614-bea8-4157-a6d9-d63f60624128)
