### PR TITLE
fix regression in HashMap.get()

### DIFF
--- a/boa/contracts/vyper/vyper_contract.py
+++ b/boa/contracts/vyper/vyper_contract.py
@@ -418,7 +418,7 @@ class StorageVar:
     def get(self, truncate_limit=None):
         if isinstance(self.typ, HashMapT):
             ret = {}
-            for k in self.contract.env.sstore_trace.get(self.addr, {}):
+            for k in self.contract.env.sstore_trace.get(self.addr, set()):
                 path = unwrap_storage_key(self.contract.env.sha3_trace, k)
                 if to_int(path[0]) != self.slot:
                     continue

--- a/boa/vm/py_evm.py
+++ b/boa/vm/py_evm.py
@@ -208,7 +208,7 @@ class Sha3PreimageTracer:
         value = computation._stack.values[-1]
         image = to_bytes(value)
 
-        self.env.sha3_trace[preimage] = image
+        self.env.sha3_trace[image] = preimage
 
 
 class SstoreTracer:
@@ -220,7 +220,7 @@ class SstoreTracer:
 
     def __call__(self, computation):
         value, slot = [to_int(t) for t in computation._stack.values[-2:]]
-        account = computation.msg.storage_address
+        account = Address(computation.msg.storage_address)
 
         # we don't want to deal with snapshots/commits/reverts, so just
         # register that the slot was touched and downstream can filter

--- a/tests/unitary/contracts/vyper/test_vyper_contract.py
+++ b/tests/unitary/contracts/vyper/test_vyper_contract.py
@@ -62,6 +62,22 @@ def __init__():
 """
     assert boa.loads(code)._storage.point.get() == [1, 2]
 
+def test_decode_hashmap():
+    code = """
+xs: HashMap[uint256, uint256]
+ys: HashMap[uint256, HashMap[uint256, uint256]]
+
+@deploy
+def __init__():
+    self.xs[5] = 6
+    self.ys[1][2] = 3
+    self.ys[2][3] = 4
+    self.ys[2][6] = 7
+"""
+    c = boa.loads(code)
+    assert c._storage.xs.get() == {5: 6}
+    assert c._storage.ys.get() == {1: {2: 3}, 2: {3: 4, 6: 7}}
+
 
 def test_self_destruct():
     code = """

--- a/tests/unitary/contracts/vyper/test_vyper_contract.py
+++ b/tests/unitary/contracts/vyper/test_vyper_contract.py
@@ -62,6 +62,7 @@ def __init__():
 """
     assert boa.loads(code)._storage.point.get() == [1, 2]
 
+
 def test_decode_hashmap():
     code = """
 xs: HashMap[uint256, uint256]


### PR DESCRIPTION
.get() was broken for HashMaps. there were two regressions, one is the type of the storage variable model address needed to be updated to the newer `Address` type. the other was that the order of preimage to image mapping was reversed in 59a78dddb2fa3662b during a larger refactor.

additionally, unit tests have been added to prevent future regressions

### What I did

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
