### PR TITLE
fix[perf]: fix performance issue in computing source map

### DIFF
--- a/boa/contracts/vyper/vyper_contract.py
+++ b/boa/contracts/vyper/vyper_contract.py
@@ -681,6 +681,11 @@ class VyperContract(_BaseVyperContract):
     @property
     def source_map(self):
         if self._source_map is None:
+            # cache- backwards compatibility (some caches might not have it
+            # until next release)
+            if hasattr(self.compiler_data, "source_map"):
+                return self.compiler_data.source_map
+
             with anchor_settings(self.compiler_data.settings):
                 assembly = self.compiler_data.assembly_runtime
                 _, self._source_map = compile_ir.assembly_to_evm(assembly)

--- a/boa/contracts/vyper/vyper_contract.py
+++ b/boa/contracts/vyper/vyper_contract.py
@@ -683,12 +683,8 @@ class VyperContract(_BaseVyperContract):
         if self._source_map is None:
             # cache- backwards compatibility (some caches might not have it
             # until next release)
-            if hasattr(self.compiler_data, "source_map"):
-                return self.compiler_data.source_map
+            self._source_map = self.compiler_data.source_map
 
-            with anchor_settings(self.compiler_data.settings):
-                assembly = self.compiler_data.assembly_runtime
-                _, self._source_map = compile_ir.assembly_to_evm(assembly)
         return self._source_map
 
     def find_error_meta(self, computation):

--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -194,7 +194,8 @@ def compiler_data(
 
 
 def _compute_source_map(compiler_data: CompilerData) -> Any:
-    return compile_ir.assembly_to_evm(compiler_data.assembly_runtime)
+    source_map, _ = compile_ir.assembly_to_evm(compiler_data.assembly_runtime)
+    return source_map
 
 
 def load(filename: str | Path, *args, **kwargs) -> _Contract:  # type: ignore

--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 
 import vvm
 import vyper
+import vyper.ir.compile_ir as compile_ir
 from packaging.version import Version
 from vvm.utils.versioning import _pick_vyper_version, detect_version_specifier_set
 from vyper.ast.parse import parse_to_ast

--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -168,6 +168,13 @@ def compiler_data(
         with anchor_settings(ret.settings):
             # force compilation to happen so DiskCache will cache the compiled artifact:
             _ = ret.bytecode, ret.bytecode_runtime
+
+            # workaround since CompilerData does not compute source_map
+            if not hasattr(ret, "source_map"):
+                # cache source map
+                assembly = ret.assembly_runtime
+                ret.source_map = compile_ir.assembly_to_evm(assembly)
+
         return ret
 
     assert isinstance(deployer, type) or deployer is None

--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -194,7 +194,7 @@ def compiler_data(
 
 
 def _compute_source_map(compiler_data: CompilerData) -> Any:
-    source_map, _ = compile_ir.assembly_to_evm(compiler_data.assembly_runtime)
+    _, source_map = compile_ir.assembly_to_evm(compiler_data.assembly_runtime)
     return source_map
 
 


### PR DESCRIPTION
the source map is not shared between VyperContract instances since it is not cached on CompilerData. this computes it before putting it into the disk cache.

### What I did

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
