### PR TITLE
fix: always add "." to search paths

### DIFF
--- a/boa/contracts/vyper/vyper_contract.py
+++ b/boa/contracts/vyper/vyper_contract.py
@@ -133,7 +133,13 @@ class VyperDeployer:
         """
         Generates a solc "standard json" representation of the Vyper contract.
         """
-        return build_solc_json(self.compiler_data)
+        ret = build_solc_json(self.compiler_data)
+        search_paths = ret["settings"]["search_paths"]
+        if "." not in search_paths:
+            # handle loads like "../../foo.vy". may be handled upstream by
+            # https://github.com/vyperlang/vyper/pull/4706
+            search_paths.append(".")
+        return ret
 
     @cached_property
     def _constants(self):


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
