### PR TITLE
feat: add Etherscanv2 API Explorer support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ venv/
 .coverage
 .coverage.*
 .DS_Store
+
+uv.lock

--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -367,8 +367,6 @@ def from_etherscan(
     chain_id: int = None,
 ):
     addr = Address(address)
-    # @dev add chain id Etherscan V2 from fork evm patch?
-    _chain_id = chain_id or Env.get_singleton().evm.patch.chain_id
 
     if uri is not None or api_key is not None:
         etherscan = Etherscan(uri, api_key)
@@ -376,7 +374,10 @@ def from_etherscan(
         etherscan = get_etherscan()
 
     # Set the chain ID for the Etherscan instance
-    etherscan.chain_id = _chain_id
+    if chain_id is not None:
+        etherscan.set_chain_id(chain_id)
+    else:
+        etherscan.set_chain_id(Env.get_singleton().evm.patch.chain_id)
 
     abi = etherscan.fetch_abi(addr)
     return ABIContractFactory.from_abi_dict(abi, name=name).at(addr)

--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -369,7 +369,8 @@ def from_etherscan(
     else:
         etherscan = get_etherscan()
 
-    abi = etherscan.fetch_abi(addr)
+    # @dev add chain id Etherscan V2 from fork evm patch
+    abi = etherscan.fetch_abi(addr, chain_id=Env.get_singleton().evm.patch.chain_id)
     return ABIContractFactory.from_abi_dict(abi, name=name).at(addr)
 
 

--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -360,17 +360,25 @@ def _loads_partial_vvm(
 
 
 def from_etherscan(
-    address: Any, name: str = None, uri: str = None, api_key: str = None
+    address: Any,
+    name: str = None,
+    uri: str = None,
+    api_key: str = None,
+    chain_id: int = None,
 ):
     addr = Address(address)
+    # @dev add chain id Etherscan V2 from fork evm patch?
+    _chain_id = chain_id or Env.get_singleton().evm.patch.chain_id
 
     if uri is not None or api_key is not None:
         etherscan = Etherscan(uri, api_key)
     else:
         etherscan = get_etherscan()
 
-    # @dev add chain id Etherscan V2 from fork evm patch
-    abi = etherscan.fetch_abi(addr, chain_id=Env.get_singleton().evm.patch.chain_id)
+    # Set the chain ID for the Etherscan instance
+    etherscan.chain_id = _chain_id
+
+    abi = etherscan.fetch_abi(addr)
     return ABIContractFactory.from_abi_dict(abi, name=name).at(addr)
 
 

--- a/boa/verifiers.py
+++ b/boa/verifiers.py
@@ -208,10 +208,6 @@ def verify(
     if (bundle := get_verification_bundle(contract)) is None:
         raise ValueError(f"Not a contract! {contract}")
 
-    # Set chain_id if verifier supports it
-    if hasattr(verifier, "chain_id"):
-        verifier.chain_id = Env.get_singleton().get_chain_id()
-
     return verifier.verify(
         address=contract.address,
         solc_json=bundle,

--- a/boa/verifiers.py
+++ b/boa/verifiers.py
@@ -22,21 +22,6 @@ class ContractVerifier(Generic[T]):
     This class should be extended by specific verifiers like Etherscan, Blockscout, etc.
     """
 
-    # Setup chain ID property in template class
-    _chain_id: Optional[int]
-
-    # Getter
-    @property
-    def chain_id(self) -> Optional[int]:
-        return self._chain_id
-
-    # Setter
-    @chain_id.setter
-    def chain_id(self, value: Optional[int]):
-        if value is None or isinstance(value, str) or value <= 0:
-            raise ValueError("Chain ID must be a positive integer.")
-        self._chain_id = value
-
     # Methods
     def verify(
         self,
@@ -223,8 +208,9 @@ def verify(
     if (bundle := get_verification_bundle(contract)) is None:
         raise ValueError(f"Not a contract! {contract}")
 
-    # Set chain_id
-    verifier.chain_id = Env.get_singleton().get_chain_id()
+    # Set chain_id if verifier supports it
+    if hasattr(verifier, "chain_id"):
+        verifier.chain_id = Env.get_singleton().get_chain_id()
 
     return verifier.verify(
         address=contract.address,

--- a/tests/integration/fork/test_from_etherscan.py
+++ b/tests/integration/fork/test_from_etherscan.py
@@ -35,6 +35,10 @@ def test_wrong_chain_id():
         boa.from_etherscan(crvusd, chain_id=-1)
     with pytest.raises(ValueError, match="Chain ID must be a positive integer."):
         boa.from_etherscan(crvusd, chain_id="invalid")
+    with pytest.raises(ValueError, match="Chain ID must be a positive integer."):
+        boa.from_etherscan(crvusd, chain_id=0.25)
+    with pytest.raises(ValueError, match="Chain ID must be a positive integer."):
+        boa.from_etherscan(crvusd, chain_id=0)
 
 
 def test_cache(proxy_contract):

--- a/tests/integration/fork/test_from_etherscan.py
+++ b/tests/integration/fork/test_from_etherscan.py
@@ -30,6 +30,13 @@ def proxy_contract():
     return boa.from_etherscan(voting_agent, name="VotingAgent")
 
 
+def test_wrong_chain_id():
+    with pytest.raises(ValueError, match="Chain ID must be a positive integer."):
+        boa.from_etherscan(crvusd, chain_id=-1)
+    with pytest.raises(ValueError, match="Chain ID must be a positive integer."):
+        boa.from_etherscan(crvusd, chain_id="invalid")
+
+
 def test_cache(proxy_contract):
     assert isinstance(SESSION, CachedSession)
     with patch("requests.adapters.HTTPAdapter.send") as mock:

--- a/tests/integration/network/sepolia/test_sepolia_env.py
+++ b/tests/integration/network/sepolia/test_sepolia_env.py
@@ -52,6 +52,27 @@ def verifier(request):
     raise ValueError(f"Unknown verifier: {request.param}")
 
 
+def test_set_etherscan_wrong_chain_id():
+    with pytest.raises(ValueError, match="Chain ID must be a positive integer."):
+        Etherscan("https://api.etherscan.io/v2/api", _chain_id=-1)
+    with pytest.raises(ValueError, match="Chain ID must be a positive integer."):
+        Etherscan("https://api.etherscan.io/v2/api", _chain_id="invalid")
+
+
+def test_set_etherscan_with_chain_id():
+    SEPOLIA_CHAIN_ID = 11155111
+    # Init verifiers with the chain ID
+    etherscan_verifier = Etherscan(
+        "https://api.etherscan.io/v2/api", _chain_id=SEPOLIA_CHAIN_ID
+    )
+    # Assert that the chain ID is set correctly
+    assert etherscan_verifier.chain_id == SEPOLIA_CHAIN_ID
+    # Set to Mainnet
+    etherscan_verifier.chain_id = 1
+    # Assert that the chain ID is set correctly
+    assert etherscan_verifier.chain_id != SEPOLIA_CHAIN_ID
+
+
 def test_verify(verifier):
     # generate a random contract so the verification will actually be done again
     name = "".join(sample(ascii_lowercase, 10))
@@ -72,9 +93,11 @@ def test_verify(verifier):
         value,
         name=name,
     )
+
     result = boa.verify(contract, verifier)
     result.wait_for_verification()
     assert result.is_verified()
+    assert verifier.chain_id == boa.env.get_chain_id()
 
 
 def test_env_type():

--- a/tests/integration/network/sepolia/test_sepolia_env.py
+++ b/tests/integration/network/sepolia/test_sepolia_env.py
@@ -48,7 +48,7 @@ def verifier(request):
         return Blockscout("https://eth-sepolia.blockscout.com", api_key)
     elif request.param == Etherscan:
         api_key = os.environ["ETHERSCAN_API_KEY"]
-        return Etherscan("https://api-sepolia.etherscan.io/api", api_key)
+        return Etherscan("https://api.etherscan.io/v2/api", api_key)
     raise ValueError(f"Unknown verifier: {request.param}")
 
 

--- a/tests/integration/network/sepolia/test_sepolia_env.py
+++ b/tests/integration/network/sepolia/test_sepolia_env.py
@@ -34,6 +34,7 @@ def raise_exception(t: uint256):
 """
 
 STARTING_SUPPLY = 100
+SEPOLIA_CHAIN_ID = 11155111
 
 
 @pytest.fixture(scope="module")
@@ -48,7 +49,9 @@ def verifier(request):
         return Blockscout("https://eth-sepolia.blockscout.com", api_key)
     elif request.param == Etherscan:
         api_key = os.environ["ETHERSCAN_API_KEY"]
-        return Etherscan("https://api.etherscan.io/v2/api", api_key)
+        return Etherscan(
+            "https://api.etherscan.io/v2/api", api_key, chain_id=SEPOLIA_CHAIN_ID
+        )
     raise ValueError(f"Unknown verifier: {request.param}")
 
 
@@ -64,7 +67,6 @@ def test_set_etherscan_wrong_chain_id():
 
 
 def test_set_etherscan_with_chain_id():
-    SEPOLIA_CHAIN_ID = 11155111
     # Init verifiers with the chain ID
     etherscan_verifier = Etherscan(
         "https://api.etherscan.io/v2/api", chain_id=SEPOLIA_CHAIN_ID
@@ -72,7 +74,7 @@ def test_set_etherscan_with_chain_id():
     # Assert that the chain ID is set correctly
     assert etherscan_verifier.chain_id == SEPOLIA_CHAIN_ID
     # Set to Mainnet
-    etherscan_verifier.chain_id = 1
+    etherscan_verifier.set_chain_id(1)
     # Assert that the chain ID is set correctly
     assert etherscan_verifier.chain_id != SEPOLIA_CHAIN_ID
 

--- a/tests/integration/network/sepolia/test_sepolia_env.py
+++ b/tests/integration/network/sepolia/test_sepolia_env.py
@@ -54,16 +54,20 @@ def verifier(request):
 
 def test_set_etherscan_wrong_chain_id():
     with pytest.raises(ValueError, match="Chain ID must be a positive integer."):
-        Etherscan("https://api.etherscan.io/v2/api", _chain_id=-1)
+        Etherscan("https://api.etherscan.io/v2/api", chain_id=-1)
     with pytest.raises(ValueError, match="Chain ID must be a positive integer."):
-        Etherscan("https://api.etherscan.io/v2/api", _chain_id="invalid")
+        Etherscan("https://api.etherscan.io/v2/api", chain_id=0)
+    with pytest.raises(ValueError, match="Chain ID must be a positive integer."):
+        Etherscan("https://api.etherscan.io/v2/api", chain_id=0.25)
+    with pytest.raises(ValueError, match="Chain ID must be a positive integer."):
+        Etherscan("https://api.etherscan.io/v2/api", chain_id="invalid")
 
 
 def test_set_etherscan_with_chain_id():
     SEPOLIA_CHAIN_ID = 11155111
     # Init verifiers with the chain ID
     etherscan_verifier = Etherscan(
-        "https://api.etherscan.io/v2/api", _chain_id=SEPOLIA_CHAIN_ID
+        "https://api.etherscan.io/v2/api", chain_id=SEPOLIA_CHAIN_ID
     )
     # Assert that the chain ID is set correctly
     assert etherscan_verifier.chain_id == SEPOLIA_CHAIN_ID


### PR DESCRIPTION
## Related issues:
- #403 
- #375

---

### What I did

Enhancing compatibility with Etherscan by migrating to Etherscan API v2.

### How I did it

#### Updates to API Compatibility:

* **Etherscan API v2 Migration**: Updated the default Etherscan URI to use the v2 endpoint and switched from using `data` payloads to query parameters for contract verification requests. Added support for `chain_id` in multiple methods to align with the new API requirements.

#### Test Case Updates:

* **Etherscan verifier**: Updated integration tests to reflect the migration to Etherscan API v2. 

#### Concerned about the following:
- `abi = etherscan.fetch_abi(addr, chain_id=Env.get_singleton().evm.patch.chain_id)` in `interpret.py` better way?

### How to verify it

Run the following test pytest:
```
pytest tests/integration/network/sepolia/test_sepolia_env.py -vvv -k test_verify
```

Should pass for Etherscan not Blockscout.

Tests not passing (unrelated or need help):
- `tests/unitary/jupyter/test_browser.py` failing `KeyError: 'eth_getBalance'`
- `tests/integration/fork/test_from_etherscan.py` failing `AssertionError` -> `test_prefetch_state[True]`

### Description for the changelog

-  Support Etherscan API v2 for improved compatibility

### Cute Animal Picture

![Owls](https://images.pexels.com/photos/32848713/pexels-photo-32848713.jpeg)
