### PR TITLE
fix: test_logs_fork fails due to incorrect import

### DIFF
--- a/tests/integration/fork/test_logs_fork.py
+++ b/tests/integration/fork/test_logs_fork.py
@@ -2,7 +2,7 @@ import pytest
 from vyper.utils import keccak256
 
 import boa
-from boa.contracts.base_evm_contract import RawEvent
+from boa.contracts.base_evm_contract import RawLogEntry
 
 WETH_ADDRESS = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
 
@@ -33,7 +33,7 @@ def test_logs(simple_contract):
     simple_contract.deposit(value=amount, sender=eoa)
 
     topic0 = keccak256("Deposit(address,uint256)".encode())
-    expected_log = (
+    (log_id, address, topics, data) = (
         0,
         int(WETH_ADDRESS, 16).to_bytes(20, "big"),
         (int.from_bytes(topic0, "big"), int(simple_contract.address, 16)),
@@ -41,4 +41,6 @@ def test_logs(simple_contract):
     )
 
     logs = simple_contract.get_logs()
-    assert logs == [RawEvent(expected_log)]
+    assert logs == [
+        RawLogEntry(log_id=log_id, address=address, topics=topics, data=data)
+    ]


### PR DESCRIPTION
### What I did

```console
______________________________________________________________________ ERROR collecting tests/integration/fork/test_logs_fork.py ______________________________________________________________________
ImportError while importing test module '/home/s3bc40/gh-projects/titanoboa/tests/integration/fork/test_logs_fork.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../.local/share/uv/python/cpython-3.12.11-linux-x86_64-gnu/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/integration/fork/test_logs_fork.py:5: in <module>
    from boa.contracts.base_evm_contract import RawEvent
E   ImportError: cannot import name 'RawEvent' from 'boa.contracts.base_evm_contract' (/home/s3bc40/gh-projects/titanoboa/boa/contracts/base_evm_contract.py)
```

Fix `test_logs_fork` fail due to incorrect import of `RawEvent` instead of `RawLogEntry` in the test.

### How I did it

#### Test Case Updates:

* **Raw Log Entry Refactor**: Replaced `RawEvent` with `RawLogEntry` in fork test logs.

### How to verify it

Run the following tests:
```
pytest tests/integration/fork/test_logs_fork.py
pytest tests/unitary -x
pytest tests/integration -x
```

Tests not passing (unrelated or need help):
- `tests/unitary/jupyter/test_browser.py` failing `KeyError: 'eth_getBalance'`
- `tests/integration/fork/test_from_etherscan.py` failing `AssertionError`

### Description for the changelog

- Fix fork log tests.

### Cute Animal Picture

![Owls](https://images.pexels.com/photos/1526404/pexels-photo-1526404.jpeg)
