### PR TITLE
Fix/verification

### DIFF
--- a/boa/explorer.py
+++ b/boa/explorer.py
@@ -78,30 +78,24 @@ class Etherscan(ContractVerifier[str]):
         if not version_match:
             raise ValueError(f"Failed to extract Vyper version from {compiler_version}")
 
-            # V2 now use query parameters instead of data
-        # @dev https://docs.etherscan.io/etherscan-v2/api-endpoints/contracts#verify-vyper-source-code
-        params = {
+        data = {
             "module": "contract",
             "action": "verifysourcecode",
             "apikey": api_key,
             "chainid": self.chain_id,
-            "contractname": f"{contract_file}:{contract_name}",
-            "compilerversion": f"vyper:{version_match.group(1)}",
-            "optimizationUsed": "1",
+            "codeformat": "vyper-json",
             "sourceCode": json.dumps(solc_json),
             "constructorArguments": constructor_calldata.hex(),
             "contractaddress": address,
-        }
-
-        # @dev maybe not needed anymore?
-        data = {
-            "codeformat": "vyper-json",
+            "contractname": f"{contract_file}:{contract_name}",
+            "compilerversion": f"vyper:{version_match.group(1)}",
+            "optimizationUsed": "1",
             "licenseType": license_type,
         }
 
         def verification_created():
             # we need to retry until the contract is found by Etherscan
-            response = SESSION.post(self.uri, params=params, data=data)
+            response = SESSION.post(self.uri, data=data)
             response.raise_for_status()
             response_json = response.json()
             if response_json.get("status") == "1":

--- a/boa/explorer.py
+++ b/boa/explorer.py
@@ -145,11 +145,12 @@ class Etherscan(ContractVerifier[str]):
         response = SESSION.get(url)
         response.raise_for_status()
         response_json = response.json()
-        if (
-            response_json.get("message") == "NOTOK"
-            and "Pending in queue" not in response_json["result"]
-        ):
-            raise ValueError(f"Failed to verify: {response_json['result']}")
+        if response_json.get("message") == "NOTOK":
+            if "Already Verified" in response_json["result"]:
+                print("Contract already verified")
+                return True
+            if "Pending in queue" not in response_json["result"]:
+                raise ValueError(f"Failed to verify: {response_json['result']}")
         return response_json.get("status") == "1"
 
     def __post_init__(self):

--- a/boa/verifiers.py
+++ b/boa/verifiers.py
@@ -205,11 +205,13 @@ def verify(
     if (bundle := get_verification_bundle(contract)) is None:
         raise ValueError(f"Not a contract! {contract}")
 
+    ctor_calldata = getattr(contract, "ctor_calldata", b"")
+
     return verifier.verify(
         address=contract.address,
         solc_json=bundle,
         contract_name=contract.contract_name,
-        constructor_calldata=getattr(contract, "ctor_calldata", b""),
+        constructor_calldata=ctor_calldata,
         wait=wait,
         **kwargs,
     )

--- a/boa/verifiers.py
+++ b/boa/verifiers.py
@@ -7,7 +7,6 @@ from typing import Callable, Generic, Optional, TypeVar
 
 import requests
 
-from boa.environment import Env
 from boa.util.abi import Address
 from boa.util.open_ctx import Open
 
@@ -83,7 +82,6 @@ class Blockscout(ContractVerifier[Address]):
         contract_name: str,
         solc_json: dict,
         constructor_calldata: bytes,
-        chain_id: int,
         license_type: str = "1",
         wait: bool = False,
     ) -> Optional["VerificationResult[Address]"]:
@@ -93,7 +91,6 @@ class Blockscout(ContractVerifier[Address]):
         :param contract_name: The name of the contract.
         :param solc_json: The solc_json output of the Vyper compiler.
         :param constructor_calldata: The calldata for the constructor.
-        :param chain_id: The ID of the chain where the contract is deployed.
         :param license_type: The license to use for the contract. Defaults to "none".
         :param wait: Whether to return a VerificationResult immediately
                      or wait for verification to complete. Defaults to False
@@ -212,7 +209,7 @@ def verify(
         address=contract.address,
         solc_json=bundle,
         contract_name=contract.contract_name,
-        constructor_calldata=contract.ctor_calldata,
+        constructor_calldata=getattr(contract, "ctor_calldata", b""),
         wait=wait,
         **kwargs,
     )

--- a/boa/verifiers.py
+++ b/boa/verifiers.py
@@ -205,6 +205,8 @@ def verify(
     if (bundle := get_verification_bundle(contract)) is None:
         raise ValueError(f"Not a contract! {contract}")
 
+    # only VyperContract has this
+    # TODO: expand VyperBlueprint and ABIContract
     ctor_calldata = getattr(contract, "ctor_calldata", b"")
 
     return verifier.verify(


### PR DESCRIPTION
### What I did

Patches to fix #424 

### How I did it

- Fixed the Etherscan API call which failed as it used params instead of data
- Fixed the handling of constructor data so that verification works for blueprints
- Avoid raising when calling `is_verified` is the contract is already verified 

### How to verify it

Deploy and verify a contract on any change

### Description for the changelog

- Fix verification issues with Etherscan 

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
