### PR TITLE
fix: add missing semicolon in moccasin dark mode CSS

### DIFF
--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -112,7 +112,7 @@
   /* dark mode */
   [data-md-color-scheme="slate"] .md-typeset .moccasin > .admonition-title,
   [data-md-color-scheme="slate"] .md-typeset .moccasin > summary {
-    background-color: rgb(246, 242, 233)
+    background-color: rgb(246, 242, 233);
   }
 
 


### PR DESCRIPTION
## Summary
- Fix missing semicolon in `docs/assets/stylesheets/extra.css` line 115
- Affects moccasin admonition dark mode styling

## Test plan
- [ ] CI docs build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)