### PR TITLE
test: mock fork account RPC calls in browser tests

### DIFF
--- a/tests/unitary/jupyter/test_browser.py
+++ b/tests/unitary/jupyter/test_browser.py
@@ -113,6 +113,9 @@ def mock_fork(mock_callback):
     mock_callback("evm_snapshot", "0x123456")
     mock_callback("evm_revert", "0x12345678")
     mock_callback("eth_chainId", "0x1")
+    mock_callback("eth_getBalance", "0x0")
+    mock_callback("eth_getTransactionCount", "0x0")
+    mock_callback("eth_getCode", "0x")
     data = {
         "number": "0x123",
         "timestamp": "0x65bbb460",


### PR DESCRIPTION
## Summary
- Mock `eth_getBalance`, `eth_getTransactionCount`, and `eth_getCode` in the BrowserEnv fork test fixture.
- Keeps BrowserEnv fork initialization exercised with newer `py-evm` behavior that preloads account state during system-contract setup.

## Rationale
- The tests themselves are unchanged since the last passing commit; failures began after dependency updates (notably `py-evm` 0.12+).
- These RPCs are part of the real fork path, so mocking them preserves the intended behavior instead of bypassing fork logic.