### PR TITLE
Docs: add Moccasin references to index and pytest tutorial

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ Titanoboa (also called `boa`) is a [Vyper](https://vyper.readthedocs.io/) interp
 - [iPython integration](guides/scripting/ipython_vyper_cells.md)
 - [native Python import syntax](guides/scripting/native_import_syntax.md)
 - [legacy Vyper support](api/vvm_deployer/overview.md)
+- [Moccasin compatibility](https://cyfrin.github.io/moccasin/) - CLI framework for full project management
 - *and more ...*
 
 `titanoboa` is not just a framework, but a library that can be used in any Python environment.

--- a/docs/tutorials/pytest.md
+++ b/docs/tutorials/pytest.md
@@ -59,6 +59,9 @@ We can run the test by calling `pytest`:
     ============================== 1 passed in 0.01s ===============================
     ```
 
+!!!moccasin
+    If you are using [Moccasin](https://cyfrin.github.io/moccasin/), you can run your tests with `mox test`, which uses pytest under the hood with additional conveniences like automatic contract deployment and network configuration.
+
 <!-- note this is just llm generated, but it's enough for now -->
 
 ## Titanoboa Plugin


### PR DESCRIPTION
What I did
Add Moccasin to the feature list in the docs overview and include a callout in the pytest tutorial explaining that Moccasin users can run tests with `mox test`.

How I did it
Updated the docs overview to include Moccasin as a Python-native smart contract development framework that uses Titanoboa under the hood
Added a note in the pytest tutorial section letting Moccasin users know they can use mox test as an alternative way to run their tests

Description for the changelog
Added Cyfrin Moccasin to docs overview feature list and pytest tutorial with mox test usage note.

