### PR TITLE
Add GitHub issue form templates for bugs and features

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name: Bug report
+description: Report unexpected behavior or a crash
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. The more detail you provide, the faster we can reproduce it.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What went wrong, in one or two sentences?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal code or commands that trigger the issue. Link to a gist or repo if needed.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include full traceback or error message if applicable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Versions that matter for reproducing (Python, titanoboa, Vyper, OS, etc.).
+      placeholder: |
+        - Python:
+        - titanoboa:
+        - vyper:
+        - OS:
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: Feature request
+description: Suggest an idea or improvement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for enhancements. For bug reports, choose **Bug report** instead.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What are you trying to do? What is hard or impossible today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would you like this to work (API shape, UX, docs, etc.)?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false


### PR DESCRIPTION
### What I did
Added GitHub issue form templates so new issues can start from structured “Bug report” or “Feature request” flows, plus a small chooser config that still allows blank issues.

### How I did it
- Added .github/ISSUE_TEMPLATE/bug_report.yml with required fields for summary, repro steps, expected vs actual behavior, and optional environment details.
- Added .github/ISSUE_TEMPLATE/feature_request.yml for problem/use case, proposed solution, and alternatives.
- Added .github/ISSUE_TEMPLATE/config.yml with blank_issues_enabled: true.

### How to verify it
1. Merge the branch (or view the files on the default branch of the repo where templates live).
2. On GitHub: Issues → New issue.
3. Confirm the template picker shows Bug report and Feature request, forms render correctly, and Open a blank issue is available.

### Description for the changelog
- Add GitHub issue templates (bug report and feature request forms).

### Cute Animal Picture
![with-all-these-fake-stuffed-platypus-pics-heres-what-actual-v0-312UbVwSo9v85GDZsg1cYvp1GdRBX_3rKbp_HfCdc74](https://github.com/user-attachments/assets/37ad1969-2a86-4bea-90c6-4b437fc38e96)

