### PR TITLE
Add priority fee strategy setting

### DIFF
--- a/boa/network.py
+++ b/boa/network.py
@@ -2,6 +2,7 @@
 import contextlib
 import time
 import warnings
+from collections.abc import Callable
 from dataclasses import dataclass
 from functools import cached_property
 from math import ceil
@@ -63,6 +64,17 @@ class _EstimateGasFailed(Exception):
     pass
 
 
+@dataclass(frozen=True)
+class PriorityFeeContext:
+    base_fee: int
+    base_fee_estimate: int
+    rpc_priority_fee: int
+    chain_id: int
+
+
+PriorityFeeStrategy = Callable[[PriorityFeeContext], int]
+
+
 @dataclass
 class TransactionSettings:
     # when calculating the base fee, the number of blocks N ahead
@@ -73,6 +85,11 @@ class TransactionSettings:
     # try increasing the constant.
     # do not recommend setting below 0.
     base_fee_estimator_constant: int = 5
+
+    # Optional strategy for EIP-1559 maxPriorityFeePerGas. Defaults to the RPC
+    # value from eth_maxPriorityFeePerGas. More context fields can be exposed
+    # in PriorityFeeContext as needed.
+    priority_fee_strategy: PriorityFeeStrategy | None = None
 
     # amount of time to wait, in seconds before giving up on a transaction
     poll_timeout: float = 240.0
@@ -267,23 +284,51 @@ class NetworkEnv(Env):
         return to_int(self._rpc.fetch("eth_gasPrice", []))
 
     def get_eip1559_fee(self) -> tuple[str, str, str, str]:
-        # returns: base_fee, max_fee, max_priority_fee
+        # returns: base_fee, max_priority_fee, max_fee, chain_id
         reqs = [
             ("eth_getBlockByNumber", ["latest", False]),
             ("eth_maxPriorityFeePerGas", []),
             ("eth_chainId", []),
         ]
-        block_info, max_priority_fee, chain_id = self._rpc.fetch_multi(reqs)
-        base_fee = block_info["baseFeePerGas"]
+        block_info, rpc_priority_fee, chain_id = self._rpc.fetch_multi(reqs)
+        base_fee = to_int(block_info["baseFeePerGas"])
 
         # Each block increases the base fee by 1/8 at most.
         # here we have the next block's base fee, compute a cap for the
         # next N blocks here.
         blocks_ahead = self.tx_settings.base_fee_estimator_constant
-        base_fee_estimate = ceil(to_int(base_fee) * (9 / 8) ** blocks_ahead)
+        base_fee_estimate = ceil(base_fee * (9 / 8) ** blocks_ahead)
 
-        max_fee = to_hex(base_fee_estimate + to_int(max_priority_fee))
-        return to_hex(base_fee_estimate), max_priority_fee, max_fee, chain_id
+        max_priority_fee = self._priority_fee(
+            base_fee=base_fee,
+            base_fee_estimate=base_fee_estimate,
+            rpc_priority_fee=to_int(rpc_priority_fee),
+            chain_id=to_int(chain_id),
+        )
+        max_fee = to_hex(base_fee_estimate + max_priority_fee)
+        return to_hex(base_fee_estimate), to_hex(max_priority_fee), max_fee, chain_id
+
+    def _priority_fee(
+        self,
+        base_fee: int,
+        base_fee_estimate: int,
+        rpc_priority_fee: int,
+        chain_id: int,
+    ) -> int:
+        strategy = self.tx_settings.priority_fee_strategy
+        if strategy is None:
+            return rpc_priority_fee
+
+        context = PriorityFeeContext(
+            base_fee=base_fee,
+            base_fee_estimate=base_fee_estimate,
+            rpc_priority_fee=rpc_priority_fee,
+            chain_id=chain_id,
+        )
+        priority_fee = strategy(context)
+        if not isinstance(priority_fee, int) or priority_fee < 0:
+            raise ValueError("priority_fee_strategy must return a non-negative int")
+        return priority_fee
 
     def get_static_fee(self) -> tuple[str, str]:
         # non eip-1559 transaction

--- a/docs/api/env/network_env.md
+++ b/docs/api/env/network_env.md
@@ -14,13 +14,14 @@ NetworkEnv is a specialized environment for interacting with real or forked bloc
 
     **Description**
 
-    Access and modify transaction settings for network interactions. These settings control gas estimation, transaction timeouts, and base fee calculations.
+    Access and modify transaction settings for network interactions. These settings control gas estimation, transaction timeouts, base fee calculations, and priority fee calculation.
 
     ---
 
     **Attributes**
 
     - `base_fee_estimator_constant`: Number of blocks ahead to estimate base fee for (default: 5)
+    - `priority_fee_strategy`: Optional function for EIP-1559 priority fee calculation. Defaults to `None`, which uses `eth_maxPriorityFeePerGas`.
     - `poll_timeout`: Timeout in seconds for waiting for transaction receipts (default: 240.0)
     - `estimate_gas_block_identifier`: Block identifier for gas estimation (default: "pending")
 
@@ -36,6 +37,12 @@ NetworkEnv is a specialized environment for interacting with real or forked bloc
     >>> # Increase timeout for slow networks
     >>> boa.env.tx_settings.poll_timeout = 300.0  # 5 minutes
     >>>
+    >>> # Set priority fee to at least 2% of the latest base fee
+    >>> boa.env.tx_settings.priority_fee_strategy = lambda ctx: max(
+    ...     ctx.rpc_priority_fee,
+    ...     ctx.base_fee // 50,
+    ... )
+    >>>
     >>> # Don't use block parameter for gas estimation (for certain RPC providers)
     >>> boa.env.tx_settings.estimate_gas_block_identifier = None
     ```
@@ -47,6 +54,8 @@ NetworkEnv is a specialized environment for interacting with real or forked bloc
     These settings are particularly useful when dealing with network congestion or RPC provider quirks.
 
     The `base_fee_estimator_constant` determines how many blocks ahead to calculate the base fee cap. Since EIP-1559 allows base fee to increase by at most 12.5% per block, the maximum base fee after n blocks is calculated as: `current_base_fee * (9/8)^n`. For example, with the default value of 5, the base fee cap would be `current_base_fee * 1.8` (approximately). If you encounter errors like "max fee per gas less than block base fee", try increasing this value.
+
+    The `priority_fee_strategy`, when set, receives a context with `base_fee`, `base_fee_estimate`, `rpc_priority_fee`, and `chain_id`, and must return the priority fee in wei as an `int`. More context fields may be exposed as needed.
 
 ---
 

--- a/tests/unitary/test_network_fees.py
+++ b/tests/unitary/test_network_fees.py
@@ -1,0 +1,82 @@
+from math import ceil
+
+import pytest
+
+from boa.network import NetworkEnv, TransactionSettings
+
+
+class FakeRPC:
+    def __init__(self, base_fee, rpc_priority_fee, chain_id):
+        self.base_fee = base_fee
+        self.rpc_priority_fee = rpc_priority_fee
+        self.chain_id = chain_id
+
+    def fetch_multi(self, reqs):
+        assert reqs == [
+            ("eth_getBlockByNumber", ["latest", False]),
+            ("eth_maxPriorityFeePerGas", []),
+            ("eth_chainId", []),
+        ]
+        return [
+            {"baseFeePerGas": hex(self.base_fee)},
+            hex(self.rpc_priority_fee),
+            hex(self.chain_id),
+        ]
+
+
+def network_env(base_fee=1000, rpc_priority_fee=7, chain_id=1):
+    env = NetworkEnv.__new__(NetworkEnv)
+    env._rpc = FakeRPC(base_fee, rpc_priority_fee, chain_id)
+    env.tx_settings = TransactionSettings()
+    return env
+
+
+def expected_base_fee_estimate(base_fee, blocks_ahead):
+    return ceil(base_fee * (9 / 8) ** blocks_ahead)
+
+
+def test_eip1559_fee_uses_rpc_priority_fee_by_default():
+    env = network_env(base_fee=1000, rpc_priority_fee=7, chain_id=5)
+
+    base_fee, priority_fee, max_fee, chain_id = env.get_eip1559_fee()
+
+    base_fee_estimate = expected_base_fee_estimate(
+        1000, env.tx_settings.base_fee_estimator_constant
+    )
+    assert base_fee == hex(base_fee_estimate)
+    assert priority_fee == hex(7)
+    assert max_fee == hex(base_fee_estimate + 7)
+    assert chain_id == hex(5)
+
+
+def test_eip1559_fee_uses_priority_fee_strategy():
+    env = network_env(base_fee=1000, rpc_priority_fee=7, chain_id=5)
+    seen_context = None
+
+    def priority_fee_strategy(context):
+        nonlocal seen_context
+        seen_context = context
+        return context.base_fee // 20
+
+    env.tx_settings.priority_fee_strategy = priority_fee_strategy
+
+    _, priority_fee, max_fee, _ = env.get_eip1559_fee()
+
+    base_fee_estimate = expected_base_fee_estimate(
+        1000, env.tx_settings.base_fee_estimator_constant
+    )
+    assert priority_fee == hex(50)
+    assert max_fee == hex(base_fee_estimate + 50)
+    assert seen_context.base_fee == 1000
+    assert seen_context.base_fee_estimate == base_fee_estimate
+    assert seen_context.rpc_priority_fee == 7
+    assert seen_context.chain_id == 5
+
+
+@pytest.mark.parametrize("priority_fee", [-1, "0x1"])
+def test_eip1559_fee_rejects_invalid_priority_fee_strategy_result(priority_fee):
+    env = network_env()
+    env.tx_settings.priority_fee_strategy = lambda context: priority_fee
+
+    with pytest.raises(ValueError, match="priority_fee_strategy"):
+        env.get_eip1559_fee()


### PR DESCRIPTION
_co-authored by gpt-5.5_

## Summary
- Add `tx_settings.priority_fee_strategy` for EIP-1559 priority fee customization.
- Keep default behavior as `eth_maxPriorityFeePerGas` when no strategy is set.
- Document the strategy context and add unit coverage for default/custom/invalid results.

## Tests
- `uv run pytest tests/unitary/test_network_fees.py`
