### PR TITLE
Support direct Venom codegen for debug wrappers

### DIFF
--- a/boa/contracts/vyper/compiler_utils.py
+++ b/boa/contracts/vyper/compiler_utils.py
@@ -11,10 +11,17 @@ from vyper.codegen.function_definitions import (
 from vyper.codegen.ir_node import IRnode
 from vyper.codegen.module import _runtime_reachable_functions, _selector_section_linear
 from vyper.compiler.settings import anchor_settings
-from vyper.exceptions import InvalidType
+from vyper.exceptions import InvalidType, VyperException
 from vyper.ir import compile_ir, optimizer
 from vyper.semantics.analysis.constant_folding import ConstantFolder
+from vyper.semantics.analysis.getters import generate_public_variable_getters
+from vyper.semantics.analysis.local import analyze_functions
+from vyper.semantics.analysis.module import ModuleAnalyzer, _analyze_call_graph
 from vyper.semantics.analysis.utils import get_exact_type_from_node
+from vyper.semantics.namespace import get_namespace
+from vyper.semantics.types.function import ContractFunctionT
+from vyper.semantics.types.module import ModuleT
+from vyper.utils import OrderedSet
 from vyper.venom import generate_assembly_experimental
 
 try:
@@ -38,6 +45,50 @@ def _swipe_constants(src_ast, dst_ast):
     s = ConstantFolder(src_ast)
     s._get_constants()
     s.visit(dst_ast)
+
+
+def _copy_namespace(namespace):
+    ret = namespace.__class__.__new__(namespace.__class__)
+    dict.update(ret, namespace)
+    ret._scopes = copy.deepcopy(namespace._scopes)
+    return ret
+
+
+def _analyze_debug_module(ast):
+    if hasattr(analysis, "analyze_module"):
+        analysis.analyze_module(ast)
+    else:
+        _analyze_debug_module_in_current_namespace(ast)
+
+
+def _analyze_debug_module_in_current_namespace(ast):
+    namespace = get_namespace()
+    with namespace.enter_scope():
+        analyzer = ModuleAnalyzer(ast, namespace)
+        analyzer.analyze_module_body()
+        ast._metadata["namespace"] = _copy_namespace(namespace)
+        generate_public_variable_getters(ast)
+        ast._metadata["type"] = ModuleT(ast)
+        analyze_functions(ast)
+        _build_debug_call_graph_edges(ast)
+        _analyze_call_graph(ast)
+
+
+def _build_debug_call_graph_edges(ast):
+    for func in ast.get_children(vy_ast.FunctionDef):
+        func_t = func._metadata["func_type"]
+        func_t.called_functions = OrderedSet()
+
+        for call in func.get_descendants(vy_ast.Call):
+            try:
+                call_t = get_exact_type_from_node(call.func)
+            except VyperException:
+                continue
+
+            if isinstance(call_t, ContractFunctionT) and (
+                call_t.is_internal or call_t.is_constructor
+            ):
+                func_t.called_functions.add(call_t.get_concrete_override())
 
 
 def _compile_assembly_with_legacy_venom(ir, settings):
@@ -118,7 +169,7 @@ def compile_vyper_function(vyper_function, contract):
         # override namespace and add wrapper code at the top
         with contract.override_vyper_namespace():
             _swipe_constants(compiler_data.annotated_vyper_module, ast)
-            analysis.analyze_module(ast)
+            _analyze_debug_module(ast)
 
         ast = ast.body[0]
         func_t = ast._metadata["func_type"]

--- a/boa/contracts/vyper/compiler_utils.py
+++ b/boa/contracts/vyper/compiler_utils.py
@@ -1,3 +1,5 @@
+import copy
+import importlib
 import textwrap
 
 import vyper.ast as vy_ast
@@ -15,11 +17,10 @@ from vyper.semantics.analysis.constant_folding import ConstantFolder
 from vyper.semantics.analysis.utils import get_exact_type_from_node
 from vyper.venom import generate_assembly_experimental
 
-# TODO remove once vyper 0.4.4 is released
 try:
-    from vyper.venom import generate_venom
+    from vyper.venom import generate_ir as _legacy_ir_to_venom
 except ImportError:
-    from vyper.venom import generate_ir as generate_venom
+    _legacy_ir_to_venom = None
 
 from boa.contracts.vyper.ir_executor import executor_from_ir
 
@@ -37,6 +38,66 @@ def _swipe_constants(src_ast, dst_ast):
     s = ConstantFolder(src_ast)
     s._get_constants()
     s.visit(dst_ast)
+
+
+def _compile_assembly_with_legacy_venom(ir, settings):
+    assert _legacy_ir_to_venom is not None
+    venom_code = _legacy_ir_to_venom(ir, settings)
+    return generate_assembly_experimental(venom_code, optimize=settings.optimize)
+
+
+def _module_with_debug_function(module_t, func_t):
+    ret = copy.copy(module_t)
+    ret.exposed_functions = [*module_t.exposed_functions, func_t]
+    return ret
+
+
+def _compile_assembly_with_direct_venom(module_t, func_t, settings):
+    try:
+        codegen_venom = importlib.import_module("vyper.codegen_venom")
+    except ImportError as exc:
+        raise ImportError(
+            "This Vyper version does not expose a supported Venom codegen API"
+        ) from exc
+
+    debug_module_t = _module_with_debug_function(module_t, func_t)
+    venom_code = codegen_venom.generate_venom_runtime(debug_module_t, settings)
+    return generate_assembly_experimental(venom_code, optimize=settings.optimize)
+
+
+def _ensure_function_ids(contract, module_t, func_t):
+    for exposed_func_t in module_t.exposed_functions:
+        contract.ensure_id(exposed_func_t)
+        for internal_func_t in exposed_func_t.reachable_internal_functions:
+            contract.ensure_id(internal_func_t)
+
+    contract.ensure_id(func_t)
+    for internal_func_t in func_t.reachable_internal_functions:
+        contract.ensure_id(internal_func_t)
+
+
+def _build_legacy_debug_ir(contract, module_t, ast, func_t):
+    # use compiler's selector section which naturally handles edge cases
+    # (such as methods with default parameters)
+    selector_section = _selector_section_linear([ast], module_t)
+
+    # first mush it with the rest of the IR in the contract to ensure
+    # all labels are present, and then optimize all together
+    # (use unoptimized IR, ir_executor can't handle optimized selector tables)
+    _, contract_runtime = contract.unoptimized_ir
+    ir_list = ["seq", selector_section, contract_runtime]
+    reachable = func_t.reachable_internal_functions
+
+    already_compiled = _runtime_reachable_functions(module_t, contract)
+    missing_functions = reachable.difference(already_compiled)
+    # TODO: cache function compilations or something
+    for f in missing_functions:
+        assert f.ast_def is not None
+        contract.ensure_id(f)
+        func_ir = generate_ir_for_internal_function(f.ast_def, module_t, False).func_ir
+        ir_list.append(func_ir)
+
+    return IRnode.from_list(ir_list)
 
 
 def compile_vyper_function(vyper_function, contract):
@@ -61,49 +122,26 @@ def compile_vyper_function(vyper_function, contract):
 
         ast = ast.body[0]
         func_t = ast._metadata["func_type"]
+        _ensure_function_ids(contract, module_t, func_t)
 
-        contract.ensure_id(func_t)
-        # use compiler's selector section which naturally handles edge
-        # cases (such as methods with default parameters)
-        selector_section = _selector_section_linear([ast], module_t)
-
-        # first mush it with the rest of the IR in the contract to ensure
-        # all labels are present, and then optimize all together
-        # (use unoptimized IR, ir_executor can't handle optimized selector tables)
-        _, contract_runtime = contract.unoptimized_ir
-        ir_list = ["seq", selector_section, contract_runtime]
-        reachable = func_t.reachable_internal_functions
-
-        already_compiled = _runtime_reachable_functions(module_t, contract)
-        missing_functions = reachable.difference(already_compiled)
-        # TODO: cache function compilations or something
-        for f in missing_functions:
-            assert f.ast_def is not None
-            contract.ensure_id(f)
-            ir_list.append(
-                generate_ir_for_internal_function(f.ast_def, module_t, False).func_ir
-            )
-
-        ir = IRnode.from_list(ir_list)
         if settings.experimental_codegen:
-            venom_code = generate_venom(ir, settings)
-            assembly = generate_assembly_experimental(
-                venom_code, optimize=settings.optimize
-            )
-
+            if _legacy_ir_to_venom is not None:
+                ir = _build_legacy_debug_ir(contract, module_t, ast, func_t)
+                assembly = _compile_assembly_with_legacy_venom(ir, settings)
+            else:
+                assembly = _compile_assembly_with_direct_venom(
+                    module_t, func_t, settings
+                )
+            ir_executor = None
         else:
+            ir = _build_legacy_debug_ir(contract, module_t, ast, func_t)
             ir = optimizer.optimize(ir)
             assembly = compile_ir.compile_to_assembly(ir)
+            ir_executor = executor_from_ir(ir, compiler_data)
 
         bytecode, source_map = compile_ir.assembly_to_evm(assembly)
         bytecode += contract.data_section
         typ = func_t.return_type
-
-        # generate the IR executor
-        if settings.experimental_codegen:
-            ir_executor = None
-        else:
-            ir_executor = executor_from_ir(ir, compiler_data)
 
         return ast, ir_executor, bytecode, source_map, typ
 

--- a/boa/contracts/vyper/vyper_contract.py
+++ b/boa/contracts/vyper/vyper_contract.py
@@ -307,6 +307,13 @@ class ErrorDetail:
         return msg
 
 
+def _copy_vyper_namespace(namespace):
+    ret = namespace.__class__.__new__(namespace.__class__)
+    dict.update(ret, namespace)
+    ret._scopes = copy.deepcopy(namespace._scopes)
+    return ret
+
+
 # "pattern match" a BoaError. tries to match fields of the error
 # to the args/kwargs provided. raises if no match
 def check_boa_error_matches(error, *args, **kwargs):
@@ -794,9 +801,7 @@ class VyperContract(_BaseVyperContract):
     @cached_property
     def _vyper_namespace(self):
         module = self.compiler_data.annotated_vyper_module
-        # make a copy of the namespace, since we might modify it
-        ret = copy.copy(module._metadata["namespace"])
-        ret._scopes = copy.deepcopy(ret._scopes)
+        ret = _copy_vyper_namespace(module._metadata["namespace"])
         if len(ret._scopes) == 0:
             # funky behavior in Namespace.enter_scope()
             ret._scopes.append(set())
@@ -942,6 +947,12 @@ class VyperFunction:
     def func_t(self):
         return self.fn_ast._metadata["func_type"]
 
+    @property
+    def is_modifying(self):
+        if hasattr(self.func_t, "is_mutable"):
+            return self.func_t.is_mutable
+        return self.func_t.is_modifying
+
     # The function type used for ABI validation/encoding. Defaults to
     # the function's own type, but subclasses (e.g., internal wrappers)
     # can override this to use a generated external wrapper signature
@@ -1069,7 +1080,7 @@ class VyperFunction:
                 data=calldata_bytes,
                 value=value,
                 gas=gas,
-                is_modifying=self.func_t.is_mutable,
+                is_modifying=self.is_modifying,
                 simulate=simulate,
                 override_bytecode=override_bytecode,
                 ir_executor=ir_executor,

--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -19,9 +19,15 @@ from vyper.compiler.input_bundle import CompilerInput, FileInput, FilesystemInpu
 from vyper.compiler.phases import CompilerData
 from vyper.compiler.settings import OptimizationLevel, Settings, anchor_settings
 from vyper.semantics.analysis.imports import resolve_imports
-from vyper.semantics.analysis.module import analyze_module
 from vyper.semantics.types.module import ModuleT
 from vyper.utils import sha256sum
+
+try:
+    from vyper.semantics.analysis.module import analyze_module as _analyze_module_ast
+    _analyze_modules = None
+except ImportError:
+    _analyze_module_ast = None
+    from vyper.semantics.analysis.module import analyze_modules as _analyze_modules
 
 from boa.contracts.abi.abi_contract import ABIContractFactory
 from boa.contracts.vvm.vvm_contract import VVMDeployer
@@ -38,6 +44,13 @@ from boa.util.disk_cache import DiskCache
 
 if TYPE_CHECKING:
     from vyper.semantics.analysis.base import ImportInfo
+
+
+def _analyze_module(ast, imports):
+    if _analyze_module_ast is not None:
+        return _analyze_module_ast(ast)
+    return _analyze_modules(imports)
+
 
 _Contract = Union[VyperContract, VyperBlueprint]
 
@@ -296,9 +309,9 @@ def loads_vyi(source_code: str, name: str = None, filename: str = None):
     else:
         ctx = contextlib.nullcontext()
     with ctx:
-        _ = resolve_imports(ast, input_bundle)
+        imports = resolve_imports(ast, input_bundle)
 
-    module_t = analyze_module(ast)
+    module_t = _analyze_module(ast, imports)
     abi = module_t.interface.to_toplevel_abi_dict()
     return ABIContractFactory(name, abi, filename=filename)
 

--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -13,21 +13,12 @@ import vyper
 import vyper.ir.compile_ir as compile_ir
 from packaging.version import Version
 from vvm.utils.versioning import _pick_vyper_version, detect_version_specifier_set
-from vyper.ast.parse import parse_to_ast
 from vyper.cli.vyper_compile import get_search_paths
 from vyper.compiler.input_bundle import CompilerInput, FileInput, FilesystemInputBundle
 from vyper.compiler.phases import CompilerData
 from vyper.compiler.settings import OptimizationLevel, Settings, anchor_settings
-from vyper.semantics.analysis.imports import resolve_imports
 from vyper.semantics.types.module import ModuleT
 from vyper.utils import sha256sum
-
-try:
-    from vyper.semantics.analysis.module import analyze_module as _analyze_module_ast
-    _analyze_modules = None
-except ImportError:
-    _analyze_module_ast = None
-    from vyper.semantics.analysis.module import analyze_modules as _analyze_modules
 
 from boa.contracts.abi.abi_contract import ABIContractFactory
 from boa.contracts.vvm.vvm_contract import VVMDeployer
@@ -44,12 +35,6 @@ from boa.util.disk_cache import DiskCache
 
 if TYPE_CHECKING:
     from vyper.semantics.analysis.base import ImportInfo
-
-
-def _analyze_module(ast, imports):
-    if _analyze_module_ast is not None:
-        return _analyze_module_ast(ast)
-    return _analyze_modules(imports)
 
 
 _Contract = Union[VyperContract, VyperBlueprint]
@@ -295,23 +280,22 @@ def load_vyi(filename: str, name: str = None) -> ABIContractFactory:
 def loads_vyi(source_code: str, name: str = None, filename: str = None):
     global _search_path
 
-    ast = parse_to_ast(source_code, is_interface=True)
-
     if name is None:
         name = "VyperContract.vyi"
 
-    search_paths = get_search_paths(_search_path)
-    input_bundle = FilesystemInputBundle(search_paths)
+    filename_for_input = filename or name
+    path = Path(filename_for_input)
+    if path.suffix != ".vyi":
+        path = path.with_suffix(".vyi")
 
-    # cf. CompilerData._resolve_imports
-    if filename is not None:
-        ctx = input_bundle.search_path(Path(filename).parent)
-    else:
-        ctx = contextlib.nullcontext()
-    with ctx:
-        imports = resolve_imports(ast, input_bundle)
-
-    module_t = _analyze_module(ast, imports)
+    file_input = FileInput(
+        contents=source_code,
+        source_id=-1,
+        path=path,
+        resolved_path=path.resolve(strict=False),
+    )
+    input_bundle = FilesystemInputBundle(get_search_paths(_search_path))
+    module_t = CompilerData(file_input, input_bundle, Settings()).global_ctx
     abi = module_t.interface.to_toplevel_abi_dict()
     return ABIContractFactory(name, abi, filename=filename)
 

--- a/tests/unitary/test_vyper_venom_compat.py
+++ b/tests/unitary/test_vyper_venom_compat.py
@@ -1,0 +1,41 @@
+import sys
+import types
+
+from boa.contracts.vyper import compiler_utils
+
+
+def test_direct_venom_debug_module_adds_wrapper_function(monkeypatch):
+    module_t = types.SimpleNamespace(exposed_functions=["existing"])
+    settings = types.SimpleNamespace(optimize="optimize")
+    calls = {}
+
+    def generate_venom_runtime(debug_module_t, actual_settings):
+        calls["debug_module_t"] = debug_module_t
+        calls["settings"] = actual_settings
+        return "venom_runtime"
+
+    def generate_assembly_experimental(venom_runtime, optimize):
+        calls["venom_runtime"] = venom_runtime
+        calls["optimize"] = optimize
+        return ["assembly"]
+
+    monkeypatch.setitem(
+        sys.modules,
+        "vyper.codegen_venom",
+        types.SimpleNamespace(generate_venom_runtime=generate_venom_runtime),
+    )
+    monkeypatch.setattr(
+        compiler_utils,
+        "generate_assembly_experimental",
+        generate_assembly_experimental,
+    )
+
+    assembly = compiler_utils._compile_assembly_with_direct_venom(
+        module_t, "debug", settings
+    )
+
+    assert assembly == ["assembly"]
+    assert calls["debug_module_t"].exposed_functions == ["existing", "debug"]
+    assert calls["settings"] is settings
+    assert calls["venom_runtime"] == "venom_runtime"
+    assert calls["optimize"] == "optimize"


### PR DESCRIPTION
_co-authored by openai gpt-5.5_

fixes https://github.com/vyperlang/titanoboa/issues/451

## Summary
- keep the legacy IRnode-to-Venom path for Vyper 0.4.x
- use direct `codegen_venom` runtime generation for Boa debug wrappers when the legacy adapter is unavailable
- add coverage for exposing the Boa debug wrapper through the direct Venom path

## Tests
- `uv run pytest tests/unitary/test_vyper_venom_compat.py tests/unitary/test_call_internal_fn.py tests/unitary/test_boa.py`
