### PR TITLE
Add eval and injection for VVM contracts

### DIFF
--- a/boa/contracts/abi/abi_contract.py
+++ b/boa/contracts/abi/abi_contract.py
@@ -125,6 +125,10 @@ class ABIFunction:
         if not self.contract or not self.contract.env:
             raise Exception(f"Cannot call {self} without deploying contract.")
 
+        override_bytecode = None
+        if hasattr(self, "_override_bytecode"):
+            override_bytecode = self._override_bytecode
+
         computation = self.contract.env.execute_code(
             to_address=self.contract.address,
             sender=sender,
@@ -134,6 +138,7 @@ class ABIFunction:
             is_modifying=self.is_mutable,
             simulate=simulate,
             contract=self.contract,
+            override_bytecode=override_bytecode,
         )
 
         val = self.contract.marshal_to_python(computation, self.return_type)

--- a/boa/contracts/vvm/vvm_contract.py
+++ b/boa/contracts/vvm/vvm_contract.py
@@ -1,8 +1,12 @@
 from functools import cached_property
 from typing import Optional
 
+import vvm
+
 from boa.contracts.abi.abi_contract import ABIContract, ABIContractFactory, ABIFunction
+from boa.contracts.vyper.compiler_utils import generate_source_for_arbitrary_stmt
 from boa.environment import Env
+from boa.rpc import to_bytes
 from boa.util.abi import Address
 from boa.util.eip5202 import generate_blueprint_bytecode
 
@@ -32,7 +36,9 @@ class VVMDeployer:
     can interact with new versions using the ABI definition.
     """
 
-    def __init__(self, abi, bytecode, name, filename):
+    def __init__(
+        self, abi, bytecode, name, filename, compiler_output, source_code, vyper_version
+    ):
         """
         Initialize a VVMDeployer instance.
         :param abi: The contract's ABI.
@@ -43,13 +49,20 @@ class VVMDeployer:
         self.bytecode: bytes = bytecode
         self.name: Optional[str] = name
         self.filename: str = filename
+        self.compiler_output = compiler_output
+        self.source_code = source_code
+        self.vyper_version = vyper_version
 
     @classmethod
-    def from_compiler_output(cls, compiler_output, name, filename):
+    def from_compiler_output(
+        cls, compiler_output, name, filename, source_code, vyper_version
+    ):
         abi = compiler_output["abi"]
         bytecode_nibbles = compiler_output["bytecode"]
         bytecode = bytes.fromhex(bytecode_nibbles.removeprefix("0x"))
-        return cls(abi, bytecode, name, filename)
+        return cls(
+            abi, bytecode, name, filename, compiler_output, source_code, vyper_version
+        )
 
     @cached_property
     def factory(self):
@@ -120,4 +133,95 @@ class VVMDeployer:
         return self.deploy(*args, **kwargs)
 
     def at(self, address, nowarn=False):
-        return self.factory.at(address, nowarn=nowarn)
+        addr = Address(address)
+        contract_name = self.name or "<unknown>"
+        functions = [
+            ABIFunction(item, contract_name)
+            for item in self.abi
+            if item.get("type") == "function"
+        ]
+        events = [item for item in self.abi if item.get("type") == "event"]
+
+        contract = VVMContract(
+            self.compiler_output,
+            self.source_code,
+            self.vyper_version,
+            name=contract_name,
+            abi=self.abi,
+            functions=functions,
+            events=events,
+            address=addr,
+            filename=self.filename,
+            nowarn=nowarn,
+        )
+
+        contract.env.register_contract(addr, contract)
+        return contract
+
+
+class VVMContract(ABIContract):
+    """
+    A deployed contract compiled with vvm, which is called via ABI.
+    """
+
+    def __init__(self, compiler_output, source_code, vyper_version, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.compiler_output = compiler_output
+        self.source_code = source_code
+        self.vyper_version = vyper_version
+
+    def inject_function(self, fn_source_code, force=False):
+        """
+        Inject a function into this VVM Contract without affecting the
+        contract's source code. Useful for testing private functionality.
+        """
+        if not hasattr(self, "inject"):
+            self.inject = lambda: None
+
+        fn = _InjectVVMFunction(fn_source_code, self)
+        if hasattr(self.inject, fn.name) and not force:
+            raise ValueError(f"already injected: {fn.name}")
+
+        setattr(self.inject, fn.name, fn)
+
+    def eval(
+        self,
+        stmt: str,
+        value: int = 0,
+        gas: Optional[int] = None,
+        sender: Optional[Address] = None,
+        return_type: Optional[str] = None,
+    ):
+        """Evaluate vyper code in the context of this contract using VVM injection."""
+        wrapper_src = generate_source_for_arbitrary_stmt(stmt, return_type)
+        fn = _InjectVVMFunction(wrapper_src, self)
+        return fn(value=value, gas=gas, sender=sender)
+
+
+class _InjectVVMFunction(ABIFunction):
+    def __init__(self, source_code: str, contract: VVMContract):
+        self._source_code = source_code
+        self.contract = contract
+        abi = [i for i in self._compiler_output["abi"] if i not in contract.abi]
+        if len(abi) != 1:
+            err = "Expected exactly one new ABI entry after injecting function. "
+            err += f"Found {abi}."
+            raise ValueError(err)
+
+        super().__init__(abi[0], contract.contract_name)
+        self.contract = contract
+
+    @cached_property
+    def _override_bytecode(self) -> bytes:
+        return to_bytes(self._compiler_output["bytecode_runtime"])
+
+    @cached_property
+    def _compiler_output(self):
+        assert isinstance(self.contract, VVMContract)
+        source = "\n".join((self.contract.source_code, self.source_code))
+        compiled = vvm.compile_source(source, vyper_version=self.contract.vyper_version)
+        return compiled["<stdin>"]
+
+    @cached_property
+    def source_code(self):
+        return self._source_code

--- a/boa/contracts/vyper/compiler_utils.py
+++ b/boa/contracts/vyper/compiler_utils.py
@@ -1,6 +1,7 @@
 import copy
 import importlib
 import textwrap
+from typing import Optional
 
 import vyper.ast as vy_ast
 import vyper.semantics.analysis as analysis
@@ -239,24 +240,39 @@ def generate_bytecode_for_internal_fn(fn):
 EVAL_FUNCTION_NAME = "__boa_debug__"
 
 
-def generate_bytecode_for_arbitrary_stmt(source_code, contract):
+def generate_bytecode_for_arbitrary_stmt(
+    source_code, contract, return_type: Optional[str] = None
+):
     """Wraps arbitrary stmts with external fn and generates bytecode"""
 
-    ast = parse_to_ast(source_code)
+    if return_type is None:
+        ast = parse_to_ast(source_code)
 
-    ast = ast.body[0]
+        ast = ast.body[0]
 
-    return_sig = ""
-    debug_body = source_code
+        if isinstance(ast, vy_ast.Expr):
+            with contract.override_vyper_namespace():
+                try:
+                    ast_typ = get_exact_type_from_node(ast.value)
+                    return_type = f"{ast_typ}"
+                except InvalidType:
+                    pass
 
-    if isinstance(ast, vy_ast.Expr):
-        with contract.override_vyper_namespace():
-            try:
-                ast_typ = get_exact_type_from_node(ast.value)
-                return_sig = f"-> {ast_typ}"
-                debug_body = f"return {source_code}"
-            except InvalidType:
-                pass
+    wrapper_code = generate_source_for_arbitrary_stmt(source_code, return_type)
+    return compile_vyper_function(wrapper_code, contract)
+
+
+def generate_source_for_arbitrary_stmt(
+    source_code: str, return_type: Optional[str] = None
+) -> str:
+    """Generate wrapper source for an arbitrary Vyper statement/expression."""
+
+    if return_type:
+        return_sig = f"-> {return_type}"
+        debug_body = f"return {source_code}"
+    else:
+        return_sig = ""
+        debug_body = source_code
 
     # wrap code in function so that we can easily generate code for it
     wrapper_code = textwrap.dedent(
@@ -267,4 +283,4 @@ def generate_bytecode_for_arbitrary_stmt(source_code, contract):
             {debug_body}
     """
     )
-    return compile_vyper_function(wrapper_code, contract)
+    return wrapper_code

--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -362,7 +362,11 @@ def _loads_partial_vvm(
     def _handle_output(compiled_src):
         compiler_output = compiled_src["<stdin>"]
         return VVMDeployer.from_compiler_output(
-            compiler_output, name=name, filename=filename
+            compiler_output,
+            name=name,
+            filename=filename,
+            source_code=source_code,
+            vyper_version=version,
         )
 
     # Ensure the cache is initialized

--- a/tests/unitary/contracts/vvm/test_vvm_eval.py
+++ b/tests/unitary/contracts/vvm/test_vvm_eval.py
@@ -1,0 +1,13 @@
+import boa
+
+
+def test_vvm_eval_expr_and_stmt():
+    src = """
+# pragma version 0.3.10
+
+bar: uint256
+"""
+    c = boa.loads(src)
+
+    assert c.eval("self.bar = 456") is None
+    assert c.eval("self.bar", return_type="uint256") == 456

--- a/tests/unitary/contracts/vvm/test_vvm_inject.py
+++ b/tests/unitary/contracts/vvm/test_vvm_inject.py
@@ -1,0 +1,40 @@
+import pytest
+
+import boa
+
+
+@pytest.fixture()
+def base_code():
+    return boa.loads(
+        """
+# pragma version 0.3.10
+
+totalSupply: public(uint256)
+"""
+    )
+
+
+@pytest.fixture()
+def inject_code():
+    return """
+@external
+def test_mint(amt: uint256):
+    self.totalSupply += amt
+"""
+
+
+def test_vvm_inject_function_mutates_state(base_code, inject_code):
+    base_code.inject_function(inject_code)
+
+    amt = 7
+    base_code.inject.test_mint(amt)
+    assert base_code.totalSupply() == amt
+
+
+def test_vvm_inject_double_vs_force(base_code, inject_code):
+    base_code.inject_function(inject_code)
+
+    with pytest.raises(ValueError):
+        base_code.inject_function(inject_code)
+
+    base_code.inject_function(inject_code, force=True)


### PR DESCRIPTION
## Summary

- keep VVM compiler/source context so deployed VVM contracts can expose debug helpers
- return a VVMContract from VVM deployers and add inject_function / eval support
- allow ABI functions to execute with temporary override bytecode