### PR TITLE
Support Vyper import_infos metadata in cache fingerprints

### DIFF
--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -127,9 +127,13 @@ def get_module_fingerprint(
 
 
 def _iter_import_infos(stmt):
-    if "import_infos" in stmt._metadata:
-        return stmt._metadata["import_infos"]
-    return (stmt._metadata["import_info"],)
+    metadata = stmt._metadata
+    if "import_infos" in metadata:
+        # Vyper 0.5+ stores one or more ImportInfo objects per import node.
+        return metadata["import_infos"]
+
+    # Vyper 0.4.x stored a single ImportInfo per import node.
+    return (metadata["import_info"],)
 
 
 def _get_import_fingerprint(import_info, seen):
@@ -141,7 +145,10 @@ def _get_import_fingerprint(import_info, seen):
 
 def _get_import_module(import_info):
     if isinstance(import_info.typ, ModuleT):
+        # Vyper 0.4.x stores imported modules directly as ModuleT.
         return import_info.typ
+
+    # Vyper 0.5+ wraps imported modules in ModuleInfo.
     return getattr(import_info.typ, "module_t", None)
 
 

--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -117,18 +117,32 @@ def get_module_fingerprint(
     seen = seen or {}
     fingerprints = []
     for stmt in module_t.import_stmts:
-        import_info = stmt._metadata["import_info"]
-        if id(import_info) not in seen:
-            if isinstance(import_info.typ, ModuleT):
-                fingerprint = get_module_fingerprint(import_info.typ, seen)
-            else:
-                fingerprint = hash_input(import_info.compiler_input)
-            seen[id(import_info)] = fingerprint
-        fingerprint = seen[id(import_info)]
-        fingerprints.append(fingerprint)
+        for import_info in _iter_import_infos(stmt):
+            if id(import_info) not in seen:
+                seen[id(import_info)] = _get_import_fingerprint(import_info, seen)
+            fingerprints.append(seen[id(import_info)])
     fingerprints.append(module_t._module.source_sha256sum)
 
     return sha256sum("".join(fingerprints))
+
+
+def _iter_import_infos(stmt):
+    if "import_infos" in stmt._metadata:
+        return stmt._metadata["import_infos"]
+    return (stmt._metadata["import_info"],)
+
+
+def _get_import_fingerprint(import_info, seen):
+    module_t = _get_import_module(import_info)
+    if module_t is not None:
+        return get_module_fingerprint(module_t, seen)
+    return hash_input(import_info.compiler_input)
+
+
+def _get_import_module(import_info):
+    if isinstance(import_info.typ, ModuleT):
+        return import_info.typ
+    return getattr(import_info.typ, "module_t", None)
 
 
 def compiler_data(

--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -140,6 +140,9 @@ def _get_import_fingerprint(import_info, seen):
     module_t = _get_import_module(import_info)
     if module_t is not None:
         return get_module_fingerprint(module_t, seen)
+
+    # Interface imports (e.g. .vyi or ABI files) do not have nested module
+    # state to recurse into; fingerprint their source input directly.
     return hash_input(import_info.compiler_input)
 
 

--- a/tests/unitary/utils/test_cache.py
+++ b/tests/unitary/utils/test_cache.py
@@ -5,6 +5,7 @@ import pytest
 from packaging.version import Version
 from vyper.compiler import CompilerData
 
+import boa.interpret as interpret
 from boa.contracts.vyper.vyper_contract import VyperDeployer
 from boa.interpret import (
     _disk_cache,
@@ -75,44 +76,66 @@ x: constant(int128) = 1000
     assert test1.filename == test2.filename
 
 
-def test_module_fingerprint_accepts_import_infos_metadata():
-    dependency = _module_for_fingerprint("dependency")
-    module_info = SimpleNamespace(module_t=dependency)
-    import_info = _import_info_for_fingerprint(module_info)
-    root = _module_for_fingerprint("root", _import_stmt(import_infos=[import_info]))
+def test_module_fingerprint_tracks_imported_module_changes(tmp_path, monkeypatch):
+    data = _compiler_data_with_import(tmp_path, monkeypatch, imported_return_value=1)
+    fingerprint = get_module_fingerprint(data.global_ctx)
 
-    assert get_module_fingerprint(root) != get_module_fingerprint(
-        _module_for_fingerprint("root")
+    changed_data = _compiler_data_with_import(
+        tmp_path, monkeypatch, imported_return_value=2
+    )
+    changed_fingerprint = get_module_fingerprint(changed_data.global_ctx)
+
+    assert changed_fingerprint != fingerprint
+
+
+def test_module_fingerprint_accepts_vyper_05_import_infos_shape(tmp_path, monkeypatch):
+    data = _compiler_data_with_import(tmp_path, monkeypatch, imported_return_value=1)
+    fingerprint = get_module_fingerprint(data.global_ctx)
+
+    _rewrite_import_metadata_to_vyper_05_shape(data.global_ctx)
+
+    assert get_module_fingerprint(data.global_ctx) == fingerprint
+
+
+def _compiler_data_with_import(tmp_path, monkeypatch, imported_return_value):
+    _write_imported_module(tmp_path, imported_return_value)
+    monkeypatch.setattr(interpret, "_search_path", [str(tmp_path)])
+    source = (tmp_path / "main.vy").read_text()
+    return compiler_data(source, "main", tmp_path / "main.vy", VyperDeployer)
+
+
+def _write_imported_module(tmp_path, imported_return_value):
+    (tmp_path / "lib.vy").write_text(
+        f"""
+@internal
+def x() -> uint256:
+    return {imported_return_value}
+"""
+    )
+    (tmp_path / "main.vy").write_text(
+        """
+import lib
+
+@external
+def foo() -> uint256:
+    return lib.x()
+"""
     )
 
 
-def test_module_fingerprint_accepts_legacy_import_info_metadata():
-    import_info = _import_info_for_fingerprint(
-        typ=SimpleNamespace(), compiler_input_hash="dependency"
-    )
-    root = _module_for_fingerprint("root", _import_stmt(import_info=import_info))
-
-    assert get_module_fingerprint(root) != get_module_fingerprint(
-        _module_for_fingerprint("root")
-    )
+def _rewrite_import_metadata_to_vyper_05_shape(module_t):
+    for stmt in module_t.import_stmts:
+        if "import_infos" in stmt._metadata:
+            continue
+        import_info = stmt._metadata.pop("import_info")
+        stmt._metadata["import_infos"] = [_module_info_import(import_info)]
 
 
-def _module_for_fingerprint(source_hash, *import_stmts):
-    return SimpleNamespace(
-        import_stmts=list(import_stmts),
-        _module=SimpleNamespace(source_sha256sum=source_hash),
-    )
-
-
-def _import_stmt(**metadata):
-    return SimpleNamespace(_metadata=metadata)
-
-
-def _import_info_for_fingerprint(typ, compiler_input_hash="unused"):
-    return SimpleNamespace(
-        typ=typ,
-        compiler_input=SimpleNamespace(sha256sum=compiler_input_hash),
-    )
+def _module_info_import(import_info):
+    typ = import_info.typ
+    if not hasattr(typ, "module_t"):
+        typ = SimpleNamespace(module_t=typ)
+    return SimpleNamespace(typ=typ, compiler_input=import_info.compiler_input)
 
 
 def _to_dict(data: CompilerData) -> dict:

--- a/tests/unitary/utils/test_cache.py
+++ b/tests/unitary/utils/test_cache.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -5,7 +6,13 @@ from packaging.version import Version
 from vyper.compiler import CompilerData
 
 from boa.contracts.vyper.vyper_contract import VyperDeployer
-from boa.interpret import _disk_cache, _loads_partial_vvm, compiler_data, set_cache_dir
+from boa.interpret import (
+    _disk_cache,
+    _loads_partial_vvm,
+    compiler_data,
+    get_module_fingerprint,
+    set_cache_dir,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -66,6 +73,46 @@ x: constant(int128) = 1000
     assert test1.abi == test2.abi == test3.abi
     assert test1.bytecode == test2.bytecode == test3.bytecode
     assert test1.filename == test2.filename
+
+
+def test_module_fingerprint_accepts_import_infos_metadata():
+    dependency = _module_for_fingerprint("dependency")
+    module_info = SimpleNamespace(module_t=dependency)
+    import_info = _import_info_for_fingerprint(module_info)
+    root = _module_for_fingerprint("root", _import_stmt(import_infos=[import_info]))
+
+    assert get_module_fingerprint(root) != get_module_fingerprint(
+        _module_for_fingerprint("root")
+    )
+
+
+def test_module_fingerprint_accepts_legacy_import_info_metadata():
+    import_info = _import_info_for_fingerprint(
+        typ=SimpleNamespace(), compiler_input_hash="dependency"
+    )
+    root = _module_for_fingerprint("root", _import_stmt(import_info=import_info))
+
+    assert get_module_fingerprint(root) != get_module_fingerprint(
+        _module_for_fingerprint("root")
+    )
+
+
+def _module_for_fingerprint(source_hash, *import_stmts):
+    return SimpleNamespace(
+        import_stmts=list(import_stmts),
+        _module=SimpleNamespace(source_sha256sum=source_hash),
+    )
+
+
+def _import_stmt(**metadata):
+    return SimpleNamespace(_metadata=metadata)
+
+
+def _import_info_for_fingerprint(typ, compiler_input_hash="unused"):
+    return SimpleNamespace(
+        typ=typ,
+        compiler_input=SimpleNamespace(sha256sum=compiler_input_hash),
+    )
 
 
 def _to_dict(data: CompilerData) -> dict:


### PR DESCRIPTION
_co-authored by openai gpt-5.5_

Fixes #453.

## Summary
- support Vyper import metadata stored as `import_infos`
- recurse through `ModuleInfo.module_t` when fingerprinting imported modules
- keep compatibility with legacy singular `import_info` metadata

## Tests
- `uv run pytest tests/unitary/utils/test_cache.py::test_module_fingerprint_accepts_import_infos_metadata tests/unitary/utils/test_cache.py::test_module_fingerprint_accepts_legacy_import_info_metadata`
- smoke-tested `boa.load()` with an imported module against local latest Vyper checkout

