### PR TITLE
Fix CI coverage collection and baseline test failures

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+source = boa

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,21 +29,21 @@ jobs:
           pip install .
 
       - name: Run Unit Tests
+        id: unit_tests
         env:
           PYTHONPATH: ${{ github.workspace }}
-          # pass internals to pytest-cov, since we are testing a pytest plugin.
-          # See https://github.com/pytest-dev/pytest-cov/blob/2c9f2170/docs/plugins.rst
-          COV_CORE_SOURCE: boa
-          COV_CORE_CONFIG: .coveragerc
-          COV_CORE_DATAFILE: .coverage.eager
-        run: >-
-          pytest
-          --cov=boa
-          --cov-append
-          --cov-report term-missing:skip-covered
-          --cov-fail-under=78
-          -nauto
-          tests/unitary/
+        # Start coverage before pytest imports boa's plugin. pytest-cov then
+        # measures the xdist workers; combine both collectors before reporting.
+        run: |
+          coverage erase
+          coverage run --parallel-mode -m pytest \
+            --cov=boa --cov-append --cov-report= -nauto tests/unitary/
+
+      - name: Report Coverage
+        if: ${{ !cancelled() && steps.unit_tests.outcome != 'skipped' }}
+        run: |
+          coverage combine --append
+          coverage report --show-missing --skip-covered --fail-under=78
 
   anvil:
     name: "integration tests (anvil)"

--- a/boa/contracts/vyper/compiler_utils.py
+++ b/boa/contracts/vyper/compiler_utils.py
@@ -6,9 +6,7 @@ from typing import Optional
 import vyper.ast as vy_ast
 import vyper.semantics.analysis as analysis
 from vyper.ast.parse import parse_to_ast
-from vyper.codegen.function_definitions import (
-    generate_ir_for_internal_function,
-)
+from vyper.codegen.function_definitions import generate_ir_for_internal_function
 from vyper.codegen.ir_node import IRnode
 from vyper.codegen.module import _runtime_reachable_functions, _selector_section_linear
 from vyper.compiler.settings import anchor_settings

--- a/boa/integrations/jupyter/browser.py
+++ b/boa/integrations/jupyter/browser.py
@@ -14,12 +14,11 @@ from os.path import dirname, join, realpath
 from typing import Any
 
 import nest_asyncio
-from IPython.display import Javascript, display
-
 from eth_account import Account
 from eth_account.datastructures import SignedMessage
-from eth_account.messages import encode_typed_data, _hash_eip191_message
+from eth_account.messages import _hash_eip191_message, encode_typed_data
 from hexbytes import HexBytes
+from IPython.display import Javascript, display
 
 from boa.integrations.jupyter.constants import (
     ADDRESS_TIMEOUT_MESSAGE,

--- a/boa/interpret.py
+++ b/boa/interpret.py
@@ -1,4 +1,3 @@
-import contextlib
 import sys
 import textwrap
 import warnings

--- a/boa/util/sqlitedb.py
+++ b/boa/util/sqlitedb.py
@@ -99,7 +99,18 @@ class SqliteCache(BaseDB):
 
         # executescript does not work in multiprocess environment
         for cmd in self._PRAGMA_CMDS:
-            self._cursor.execute(cmd)
+            # Switching journal mode can contend with another worker before
+            # we can acquire a transaction lock. Keep retries bounded and
+            # propagate errors unrelated to contention.
+            deadline = time.monotonic() + 10
+            while True:
+                try:
+                    self._cursor.execute(cmd)
+                    break
+                except sqlite3.OperationalError as e:
+                    if str(e) != "database is locked" or time.monotonic() >= deadline:
+                        raise
+                    time.sleep(1e-4)
         with self.acquire_write_lock():
             for cmd in self._CREATE_CMDS:
                 self._cursor.execute(cmd)

--- a/boa/vm/py_evm.py
+++ b/boa/vm/py_evm.py
@@ -161,7 +161,15 @@ class TracingCodeStream(CodeStream):
         "program_counter",
     ]
 
-    def __init__(self, *args, start_pc=0, fake_codesize=None, contract=None, _trace_jumpi=False, **kwargs):
+    def __init__(
+        self,
+        *args,
+        start_pc=0,
+        fake_codesize=None,
+        contract=None,
+        _trace_jumpi=False,
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
         self._trace = []  # trace of opcodes that were run
         self._jumpi_conditions = {} if _trace_jumpi else None

--- a/tests/unitary/jupyter/test_browser.py
+++ b/tests/unitary/jupyter/test_browser.py
@@ -349,9 +349,7 @@ def test_sign_typed_data_eip712_with_components(
 
     # Create expected signature using eth_account
     signable = encode_typed_data(
-        domain_data=domain_data,
-        message_types=message_types,
-        message_data=message_data,
+        domain_data=domain_data, message_types=message_types, message_data=message_data
     )
     signed = account.sign_message(signable)
 
@@ -360,9 +358,7 @@ def test_sign_typed_data_eip712_with_components(
 
     # Call the method
     result = env.signer.sign_typed_data_eip712(
-        domain_data=domain_data,
-        message_types=message_types,
-        message_data=message_data,
+        domain_data=domain_data, message_types=message_types, message_data=message_data
     )
 
     # Verify result
@@ -416,22 +412,18 @@ def test_sign_typed_data_eip712_returns_signed_message(
     message_data = {"data": "test"}
 
     signable = encode_typed_data(
-        domain_data=domain_data,
-        message_types=message_types,
-        message_data=message_data,
+        domain_data=domain_data, message_types=message_types, message_data=message_data
     )
     signed = account.sign_message(signable)
     mock_callback("eth_signTypedData_v4", signed.signature.hex())
 
     result = env.signer.sign_typed_data_eip712(
-        domain_data=domain_data,
-        message_types=message_types,
-        message_data=message_data,
+        domain_data=domain_data, message_types=message_types, message_data=message_data
     )
 
     # Verify SignedMessage structure
     assert isinstance(result, SignedMessage)
-    assert hasattr(result, "messageHash")
+    assert result.message_hash == signed.message_hash
     assert hasattr(result, "r")
     assert hasattr(result, "s")
     assert hasattr(result, "v")
@@ -450,9 +442,7 @@ def test_sign_typed_data_eip712_v_normalization(
     message_data = {"data": "test"}
 
     signable = encode_typed_data(
-        domain_data=domain_data,
-        message_types=message_types,
-        message_data=message_data,
+        domain_data=domain_data, message_types=message_types, message_data=message_data
     )
     signed = account.sign_message(signable)
 
@@ -462,17 +452,15 @@ def test_sign_typed_data_eip712_v_normalization(
 
     # Also create the properly normalized version for recovery
     normalized_sig = bytes(signed.signature[:64]) + bytes([27])
-    normalized_hex = "0x" + normalized_sig.hex()
 
     mock_callback("eth_signTypedData_v4", sig_hex)
 
     result = env.signer.sign_typed_data_eip712(
-        domain_data=domain_data,
-        message_types=message_types,
-        message_data=message_data,
+        domain_data=domain_data, message_types=message_types, message_data=message_data
     )
 
     # Verify v was normalized
+    assert result.signature == normalized_sig
     assert result.v in (27, 28), f"Expected v to be 27 or 28, got {result.v}"
 
 
@@ -485,18 +473,14 @@ def test_sign_typed_data_eip712_signature_recovery(
     message_data = {"data": "test"}
 
     signable = encode_typed_data(
-        domain_data=domain_data,
-        message_types=message_types,
-        message_data=message_data,
+        domain_data=domain_data, message_types=message_types, message_data=message_data
     )
     signed = account.sign_message(signable)
     mock_callback("eth_signTypedData_v4", signed.signature.hex())
 
     # This should succeed without raising ValueError
     result = env.signer.sign_typed_data_eip712(
-        domain_data=domain_data,
-        message_types=message_types,
-        message_data=message_data,
+        domain_data=domain_data, message_types=message_types, message_data=message_data
     )
 
     # Verify we can recover the correct address
@@ -515,9 +499,7 @@ def test_sign_typed_data_eip712_invalid_signature(
     # Create a signature from a different account
     different_account = Account.create()
     signable = encode_typed_data(
-        domain_data=domain_data,
-        message_types=message_types,
-        message_data=message_data,
+        domain_data=domain_data, message_types=message_types, message_data=message_data
     )
     wrong_signed = different_account.sign_message(signable)
 
@@ -554,17 +536,13 @@ def test_sign_typed_data_eip712_bytes_serialization(
     message_data = {"data": nonce_bytes, "value": 100}
 
     signable = encode_typed_data(
-        domain_data=domain_data,
-        message_types=message_types,
-        message_data=message_data,
+        domain_data=domain_data, message_types=message_types, message_data=message_data
     )
     signed = account.sign_message(signable)
     mock_callback("eth_signTypedData_v4", signed.signature.hex())
 
     result = env.signer.sign_typed_data_eip712(
-        domain_data=domain_data,
-        message_types=message_types,
-        message_data=message_data,
+        domain_data=domain_data, message_types=message_types, message_data=message_data
     )
 
     assert isinstance(result, SignedMessage)

--- a/tests/unitary/jupyter/test_handlers.py
+++ b/tests/unitary/jupyter/test_handlers.py
@@ -73,11 +73,15 @@ def test_invalid_token(callback_handler, token):
 
 
 def test_value_error(callback_handler, token, shared_memory):
-    callback_handler.request.body = b"0" * SHARED_MEMORY_LENGTH  # no space for the \0
+    # Some platforms round the allocation up to a page boundary.
+    callback_handler.request.body = b"0" * shared_memory.size  # no space for the \0
     callback_handler.post(token)
     assert callback_handler.get_status() == 413
     callback_handler.finish.assert_called_once_with(
-        {"error": "Request body has 102401 bytes, but only 102400 are allowed"}
+        {
+            "error": f"Request body has {shared_memory.size} bytes, "
+            f"but only {shared_memory.size - 1} are allowed"
+        }
     )
 
 

--- a/tests/unitary/test_coverage/test_branch.py
+++ b/tests/unitary/test_coverage/test_branch.py
@@ -11,6 +11,7 @@ Multiline tests are in test_branch_multiline.py.
 
 import pytest
 import vyper.ast as vy_ast
+from coverage.files import canonical_filename
 from vyper.ast.parse import parse_to_ast
 
 import boa
@@ -693,6 +694,7 @@ def foo(x: uint256) -> uint256:
         return 0
 """
     with _coverage_session_lines(source, lambda c: c.foo(10)) as (cov, vy_path):
+        vy_path = canonical_filename(vy_path)
         data = cov.get_data()
         measured = data.measured_files()
         assert vy_path in measured, f"{vy_path} not in measured files: {measured}"

--- a/tests/unitary/test_env_timestamp.py
+++ b/tests/unitary/test_env_timestamp.py
@@ -20,7 +20,8 @@ def test_env_timestamp():
 
 
 def test_timestamp_correctness():
-    # amount of "timer slack" to allow in the CI since it may take some
-    # time between when boa.env is initialized and when this test is run.
-    timer_slack = 60
-    assert abs(boa.env.timestamp - time.time()) < timer_slack, "bad time"
+    before = int(time.time())
+    env = boa.Env()
+    after = int(time.time())
+    # The first block must be at least one second after genesis.
+    assert before <= env.timestamp <= after + 1, "bad time"

--- a/tests/unitary/test_isolation.py
+++ b/tests/unitary/test_isolation.py
@@ -55,7 +55,6 @@ def test_pytest_isolation(boa_contract, a, b):
 
 
 @pytest.fixture(scope="module")
-@pytest.mark.ignore_isolation
 def setup_ignore_isolation(boa_contract):
     assert boa_contract.a() == A_INIT
     assert boa_contract.b() == B_INIT

--- a/tests/unitary/test_vyper_venom_compat.py
+++ b/tests/unitary/test_vyper_venom_compat.py
@@ -25,9 +25,7 @@ def test_direct_venom_debug_module_adds_wrapper_function(monkeypatch):
         types.SimpleNamespace(generate_venom_runtime=generate_venom_runtime),
     )
     monkeypatch.setattr(
-        compiler_utils,
-        "generate_assembly_experimental",
-        generate_assembly_experimental,
+        compiler_utils, "generate_assembly_experimental", generate_assembly_experimental
     )
 
     assembly = compiler_utils._compile_assembly_with_direct_venom(

--- a/tests/unitary/utils/test_fork_cache.py
+++ b/tests/unitary/utils/test_fork_cache.py
@@ -1,5 +1,3 @@
-import pytest
-
 from boa.vm.fork import CachingRPC, _is_loopback
 
 
@@ -49,12 +47,8 @@ class TestCacheFilepath:
 
     def test_localhost_isolated(self):
         """Different localhost ports should get different cache files."""
-        path1 = CachingRPC._cache_filepath(
-            "/tmp/cache", 31337, "http://localhost:8545"
-        )
-        path2 = CachingRPC._cache_filepath(
-            "/tmp/cache", 31337, "http://localhost:8546"
-        )
+        path1 = CachingRPC._cache_filepath("/tmp/cache", 31337, "http://localhost:8545")
+        path2 = CachingRPC._cache_filepath("/tmp/cache", 31337, "http://localhost:8546")
         assert path1 != path2
         assert "chainid_0x7a69" in str(path1)
         assert "chainid_0x7a69" in str(path2)

--- a/tests/unitary/utils/test_sqlitedb.py
+++ b/tests/unitary/utils/test_sqlitedb.py
@@ -1,0 +1,52 @@
+import sqlite3
+from unittest.mock import Mock
+
+import pytest
+
+from boa.util import sqlitedb
+from boa.util.sqlitedb import SqliteCache
+
+
+@pytest.fixture
+def locked_database(tmp_path):
+    path = tmp_path / "cache.sqlite"
+    with sqlite3.connect(path, isolation_level=None) as connection:
+        connection.execute("CREATE TABLE sentinel (value)")
+        connection.execute("BEGIN IMMEDIATE")
+        try:
+            yield path, connection
+        finally:
+            connection.rollback()
+    connection.close()
+
+
+def test_initialization_retries_locked_journal_mode(locked_database, monkeypatch):
+    path, connection = locked_database
+    release = Mock(side_effect=lambda _: connection.rollback())
+    monkeypatch.setattr(sqlitedb.time, "sleep", release)
+
+    cache = SqliteCache(path)
+    try:
+        release.assert_called_once()
+        assert cache.db.execute("PRAGMA journal_mode").fetchone() == ("wal",)
+        cache[b"key"] = b"value"
+        assert cache[b"key"] == b"value"
+    finally:
+        cache._flush()
+        cache.db.close()
+
+
+def test_initialization_lock_timeout_is_not_silenced(locked_database, monkeypatch):
+    path, _ = locked_database
+    monkeypatch.setattr(sqlitedb.time, "monotonic", Mock(side_effect=[0, 11]))
+    with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+        SqliteCache(path)
+
+
+def test_initialization_does_not_retry_other_errors(monkeypatch):
+    monkeypatch.setattr(SqliteCache, "_PRAGMA_CMDS", ["invalid SQL"])
+    sleep = Mock()
+    monkeypatch.setattr(sqlitedb.time, "sleep", sleep)
+    with pytest.raises(sqlite3.OperationalError, match="syntax error"):
+        SqliteCache(":memory:")
+    sleep.assert_not_called()


### PR DESCRIPTION
Collect boa's pytest-plugin imports before pytest starts, then combine those measurements with pytest-cov's xdist worker data before applying the existing 78% coverage gate. Replace the obsolete coverage environment variables with an explicit configuration.

Update the isolation and signing tests for current pytest and eth-account, and make shared-memory, coverage-path and timestamp assertions work across platforms and longer test runs. Apply the existing Black/isort rules and remove unused imports.

Retry transient SQLite journal-mode initialization locks with a bounded deadline. Add regressions for lock recovery, timeout reporting and immediate propagation of unrelated SQL errors.
